### PR TITLE
Fix links to nowhere in TN1 notebook

### DIFF
--- a/braket_features/Using_the_tensor_network_simulator_TN1.ipynb
+++ b/braket_features/Using_the_tensor_network_simulator_TN1.ipynb
@@ -32,7 +32,7 @@
     "    \n",
     "As we will see below, if this situation occurs for a task for which you have requested a large number of shots, the task may be successful if you lower the shot count. It can also occur, albeit rarely, that the time to find a single contraction path candidate exceeds TN1's internal rehearsal runtime limit -- circuits for which this occurs are extremely unlikely to be contractable in reasonable time. In this case, the `failureReason` for the task will be `No viable contraction path found.`\n",
     "    \n",
-    "To learn more about why these two stages are present and what the simulator does in each, you can read the TN1 documentation [here](https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html)."
+    "To learn more about why these two stages are present and what the simulator does in each, you can read the TN1 documentation [here](https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html#braket-simulator-tn1)."
    ]
   },
   {

--- a/braket_features/Using_the_tensor_network_simulator_TN1.ipynb
+++ b/braket_features/Using_the_tensor_network_simulator_TN1.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "## How TN1 Works\n",
     "\n",
-    "A tensor network simulator models the execution of circuits on a quantum computer by representing each gate in the circuit as a *tensor*. Tensors generalize the concept of vectors and matrices to higher dimensions. The gates in the network form a graph. The simulator works by finding an efficient way to multiply all the different tensors on the graph during the _rehearsal_ stage and then, after a suitable multiplication sequence or _path_ is found, it performs these multiplications in the _contraction_ stage. For more information about TN1 and how it works, see the [TN1 docs]().\n",
+    "A tensor network simulator models the execution of circuits on a quantum computer by representing each gate in the circuit as a *tensor*. Tensors generalize the concept of vectors and matrices to higher dimensions. The gates in the network form a graph. The simulator works by finding an efficient way to multiply all the different tensors on the graph during the _rehearsal_ stage and then, after a suitable multiplication sequence or _path_ is found, it performs these multiplications in the _contraction_ stage. For more information about TN1 and how it works, see the [TN1 docs](https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html).\n",
     "\n",
     "## How is this different from SV1, the state vector simulator?\n",
     "\n",
@@ -32,7 +32,7 @@
     "    \n",
     "As we will see below, if this situation occurs for a task for which you have requested a large number of shots, the task may be successful if you lower the shot count. It can also occur, albeit rarely, that the time to find a single contraction path candidate exceeds TN1's internal rehearsal runtime limit -- circuits for which this occurs are extremely unlikely to be contractable in reasonable time. In this case, the `failureReason` for the task will be `No viable contraction path found.`\n",
     "    \n",
-    "To learn more about why these two stages are present and what the simulator does in each, you can read the TN1 documentation [here](TODO)."
+    "To learn more about why these two stages are present and what the simulator does in each, you can read the TN1 documentation [here](https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html)."
    ]
   },
   {

--- a/braket_features/Using_the_tensor_network_simulator_TN1.ipynb
+++ b/braket_features/Using_the_tensor_network_simulator_TN1.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "## How TN1 Works\n",
     "\n",
-    "A tensor network simulator models the execution of circuits on a quantum computer by representing each gate in the circuit as a *tensor*. Tensors generalize the concept of vectors and matrices to higher dimensions. The gates in the network form a graph. The simulator works by finding an efficient way to multiply all the different tensors on the graph during the _rehearsal_ stage and then, after a suitable multiplication sequence or _path_ is found, it performs these multiplications in the _contraction_ stage. For more information about TN1 and how it works, see the [TN1 docs](https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html).\n",
+    "A tensor network simulator models the execution of circuits on a quantum computer by representing each gate in the circuit as a *tensor*. Tensors generalize the concept of vectors and matrices to higher dimensions. The gates in the network form a graph. The simulator works by finding an efficient way to multiply all the different tensors on the graph during the _rehearsal_ stage and then, after a suitable multiplication sequence or _path_ is found, it performs these multiplications in the _contraction_ stage. For more information about TN1 and how it works, see the [TN1 docs](https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html#braket-simulator-tn1).\n",
     "\n",
     "## How is this different from SV1, the state vector simulator?\n",
     "\n",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We uploaded the original version of the TN1 notebook without doc links. This PR fixes that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
