### PR TITLE
Fix: Remove references to PennyLane's tape mode as per PennyLane v0.14

### DIFF
--- a/examples/pennylane/1_Parallelized_optimization_of_quantum_circuits.ipynb
+++ b/examples/pennylane/1_Parallelized_optimization_of_quantum_circuits.ipynb
@@ -84,7 +84,6 @@
     "import pennylane as qml\n",
     "from pennylane import numpy as np\n",
     "\n",
-    "qml.enable_tape()\n",
     "wires = 25\n",
     "\n",
     "# Please enter the S3 bucket you created during onboarding\n",
@@ -95,13 +94,6 @@
     "s3_folder = (my_bucket, my_prefix)\n",
     "\n",
     "device_arn = \"arn:aws:braket:::device/quantum-simulator/amazon/sv1\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We've also enabled [tape mode](https://pennylane.readthedocs.io/en/stable/code/qml_tape.html) in PennyLane using ``qml.enable_tape()`` to unlock the latest features."
    ]
   },
   {

--- a/examples/pennylane/2_Graph_optimization_with_QAOA.ipynb
+++ b/examples/pennylane/2_Graph_optimization_with_QAOA.ipynb
@@ -164,8 +164,6 @@
     "import pennylane as qml\n",
     "from pennylane import numpy as np\n",
     "\n",
-    "qml.enable_tape()  # unlocks the latest features in PennyLane\n",
-    "\n",
     "cost_h, mixer_h = qml.qaoa.max_clique(g, constrained=False)\n",
     "# constrained=True results in greater circuit depth but potentially better solutions\n",
     "\n",

--- a/examples/pennylane/3_Quantum_chemistry_with_VQE.ipynb
+++ b/examples/pennylane/3_Quantum_chemistry_with_VQE.ipynb
@@ -36,9 +36,7 @@
    "source": [
     "import pennylane as qml\n",
     "from pennylane import qchem\n",
-    "from pennylane import numpy as np\n",
-    "\n",
-    "qml.enable_tape()  # Unlocks the latest features in PennyLane"
+    "from pennylane import numpy as np"
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The new core of PennyLane (formerly known as "tape mode") has been the default since PennyLane v0.14 ([release notes](https://pennylane.readthedocs.io/en/stable/development/release_notes.html)), and the old core will be removed in the next release ([PR](https://github.com/PennyLaneAI/pennylane/pull/1100)). This means that calls to `qml.enable_tape()` are redundant now and will return an error in the next PennyLane release.

This PR removes calls to `qml.enable_tape()`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
