### PR TITLE
added num_reads to configure num shots per task in the qbsolv notebook

### DIFF
--- a/examples/quantum_annealing/Running_large_problems_using_QBSolv.ipynb
+++ b/examples/quantum_annealing/Running_large_problems_using_QBSolv.ipynb
@@ -155,7 +155,7 @@
     "num_repeats = 2\n",
     "\n",
     "# define the number of shots (or reads) per task on the D-Wave QPU\n",
-    "num_reads = 100 # The default value for D-Wave Advantage_system1 is 1000\n",
+    "num_reads = 100 # the default value for D-Wave Advantage_system1 is 1000\n",
     "\n",
     "response = QBSolv().sample_qubo(QUBO, solver=solver, num_repeats=num_repeats, solver_limit=solver_limit, num_reads=num_reads)\n",
     "print(response)"
@@ -171,9 +171,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "conda_braket",
    "language": "python",
-   "name": "python3"
+   "name": "conda_braket"
   },
   "language_info": {
    "codemirror_mode": {
@@ -185,7 +185,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,

--- a/examples/quantum_annealing/Running_large_problems_using_QBSolv.ipynb
+++ b/examples/quantum_annealing/Running_large_problems_using_QBSolv.ipynb
@@ -154,8 +154,8 @@
     "# define the number of repeats for the hybrid solver to search for the optimal solution.\n",
     "num_repeats = 2\n",
     "\n",
-    "# define the number of shots per task for the hybrid solver to search for the optimal solution.\n",
-    "num_reads = 1000 # default value set by D-wave is 1000 per task\n",
+    "# # define the number of shots (or reads) per task on the D-Wave QPU\n",
+    "num_reads = 100 # The default value for D-Wave Advantage_system1 is 1000\n",
     "\n",
     "response = QBSolv().sample_qubo(QUBO, solver=solver, num_repeats=num_repeats, solver_limit=solver_limit, num_reads=num_reads)\n",
     "print(response)"
@@ -185,7 +185,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/examples/quantum_annealing/Running_large_problems_using_QBSolv.ipynb
+++ b/examples/quantum_annealing/Running_large_problems_using_QBSolv.ipynb
@@ -154,7 +154,7 @@
     "# define the number of repeats for the hybrid solver to search for the optimal solution.\n",
     "num_repeats = 2\n",
     "\n",
-    "# # define the number of shots (or reads) per task on the D-Wave QPU\n",
+    "# define the number of shots (or reads) per task on the D-Wave QPU\n",
     "num_reads = 100 # The default value for D-Wave Advantage_system1 is 1000\n",
     "\n",
     "response = QBSolv().sample_qubo(QUBO, solver=solver, num_repeats=num_repeats, solver_limit=solver_limit, num_reads=num_reads)\n",

--- a/examples/quantum_annealing/Running_large_problems_using_QBSolv.ipynb
+++ b/examples/quantum_annealing/Running_large_problems_using_QBSolv.ipynb
@@ -154,7 +154,10 @@
     "# define the number of repeats for the hybrid solver to search for the optimal solution.\n",
     "num_repeats = 2\n",
     "\n",
-    "response = QBSolv().sample_qubo(QUBO, solver=solver, num_repeats=num_repeats, solver_limit=solver_limit)\n",
+    "# define the number of shots per task for the hybrid solver to search for the optimal solution.\n",
+    "num_reads = 1000 # default value set by D-wave is 1000 per task\n",
+    "\n",
+    "response = QBSolv().sample_qubo(QUBO, solver=solver, num_repeats=num_repeats, solver_limit=solver_limit, num_reads=num_reads)\n",
     "print(response)"
    ]
   },
@@ -168,9 +171,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "conda_braket",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda_braket"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -182,7 +185,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

Added a QBSolv parameter 'num_reads' to allow users to adjust the number of shots per task when use QBSolv().sample_qub(...).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
