### PR TITLE
fix qubit index in noise example

### DIFF
--- a/examples/braket_features/Simulating_Noise_On_Amazon_Braket.ipynb
+++ b/examples/braket_features/Simulating_Noise_On_Amazon_Braket.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "# Simulating noise on Amazon Braket\n",
     "\n",
@@ -25,11 +24,11 @@
     "        * [Applying readout noise to the circuit](#readout-noise)\n",
     "    * [Using both the direct and global methods to apply noise](#both)\n",
     "* [Running a noisy circuit](#run)"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Background <a class=\"anchor\" id=\"Background\"></a>\n",
     "\n",
@@ -46,78 +45,69 @@
     "The so-called _Kraus representation_ is a commonly used representation for CPTP maps. [Kraus's theorem](https://en.wikipedia.org/wiki/Quantum_operation#Kraus_operators) states that any quantum operation acting on a quantum state $\\rho$ can be expressed as a map $\\varepsilon(\\rho) = \\sum_i K_i\\rho K_i^{\\dagger}$, and it satisfies: $\\sum_i K_i^{\\dagger}K_i = \\mathbb{1}$, where $\\mathbb{1}$ is the Identity operator.\n",
     "\n",
     "Let's get started and have a look how you can define and simulate noisy circuits on Amazon Braket."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## General imports <a class=\"anchor\" id=\"imports\"></a>"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Let's begin with the usual imports and setting our s3 location where we want to persist results."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "from braket.circuits import Circuit, Observable, Gate, Noise\n",
     "from braket.devices import LocalSimulator\n",
     "from braket.aws import AwsDevice\n",
     "import numpy as np\n",
     "from scipy.stats import unitary_group"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "<div class=\"alert alert-block alert-info\">\n",
     "    <b>Note</b> Enter your desired S3 location (bucket and prefix). Remember that bucket names for Amazon Braket always begin with \"amazon-braket-\". \n",
     "</div>\n"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "# enter the S3 bucket you created during onboarding (or any other bucket starting with \"amazon-braket-\") \n",
     "my_bucket = \"amazon-braket-Your-Bucket-Name\" # the name of the bucket\n",
     "my_prefix = \"Your-Folder-Name\" # the name of the folder in the bucket\n",
     "s3_folder = (my_bucket, my_prefix)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Quick start <a class=\"anchor\" id=\"start\"></a>\n",
     "\n",
     "Let's start with a simple example of running a noisy circuit on Amazon Braket. "
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "measurement results: Counter({'11': 419, '00': 410, '10': 98, '01': 73})\n"
-     ]
-    }
-   ],
    "source": [
     "# build a simple circuit\n",
     "circ = Circuit().h(0).cnot(0,1)\n",
@@ -138,30 +128,30 @@
     "result = task.result()\n",
     "measurment = result.measurement_counts\n",
     "print('measurement results:', measurment)"
-   ]
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "measurement results: Counter({'00': 418, '11': 385, '01': 102, '10': 95})\n"
+     ]
+    }
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Ideally, in the noise-free case, the circuit we defined prepares a Bell-state, and we would expect to measure only '00' and '11' outcomes. However, the presence of noise, in our case a bit flip error, means that sometimes we find the state in '01' and '10' instead.\n",
     "\n",
     "The local simulator is suitable for fast prototyping on small circuits. If you want to run a noisy circuit with more than 10~12 qubits, we recommend using the managed simulator DM1. Using DM1, you can run circuits with up to 17 qubits, and benefit from parallel execution for a group of circuits. The code below shows an example of preparing a 13-qubit GHZ state in the presence of noise."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "measurement results: Counter({'1110111110000': 1, '1101111111110': 1, '0100000000000': 1, '1100100011001': 1, '0000000000000': 1, '1111111111101': 1, '1111111000000': 1, '0010000011000': 1, '1111111111111': 1, '0001000000000': 1})\n"
-     ]
-    }
-   ],
+   "execution_count": 4,
    "source": [
     "def ghz_circuit(n_qubits: int) -> Circuit:\n",
     "    \"\"\"\n",
@@ -193,18 +183,27 @@
     "result = task.result()\n",
     "measurment = result.measurement_counts\n",
     "print('measurement results:', measurment)"
-   ]
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "measurement results: Counter({'0000000000000': 2, '0011000000001': 1, '0111110000000': 1, '1000010100000': 1, '1000001000000': 1, '1110111111110': 1, '1110000000011': 1, '0011001000000': 1, '0000001101011': 1})\n"
+     ]
+    }
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "We now start exploring the detailed instructions and use cases of each step in the following sections."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Defining noise channels <a class=\"anchor\" id=\"noise_channels\"></a>\n",
     "\n",
@@ -234,23 +233,33 @@
     "|:----------------------- |:--------------------------------------------------  |:------------|\n",
     "|   `TwoQubitDepolarizing`|  $(1-p)\\rho$ + $p/15(IX\\rho IX$ + $IY\\rho IY$ + $IZ\\rho IZ$ + $XI\\rho XI$ +....+ $ZZ\\rho ZZ)$| $p$ is the probability of the two-qubit depolarizing noise (the 15 possible error combinations share the same probability of $p/15$).|\n",
     "|   `TwoQubitDephasing`   |  $(1-p)\\rho$ + $p/3(IZ\\rho IZ$ + $ZI\\rho ZI$ + $ZZ\\rho ZZ)$| $p$ is the probability of the two-qubit dephasing noise (the three possible error combinations share the same probability of $p/3$). |"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "The following code block takes the example of the bit flip noise channel: $\\rho\\rightarrow(1-p)\\rho$ + $pX\\rho X$, where $p$ corresponds to the `probability` parameter when defining the noise. This noise channel is equivalent to applying a bit flip error (applying an X gate) with probability $p$ and doing nothing with probability $1-p$. You can check the target qubit count and the Kraus operators of the noise channel defined."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
+   "execution_count": 5,
+   "source": [
+    "# define a bit flip noise channel with probability = 0.1\n",
+    "noise = Noise.BitFlip(probability=0.1)\n",
+    "\n",
+    "print('name: ', noise.name)\n",
+    "print('qubit count: ', noise.qubit_count)\n",
+    "print('Kraus operators: ')\n",
+    "for matrix in noise.to_matrix():\n",
+    "    print(matrix, '\\n')\n"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "name:  BitFlip\n",
       "qubit count:  1\n",
@@ -264,29 +273,18 @@
      ]
     }
    ],
-   "source": [
-    "# define a bit flip noise channel with probability = 0.1\n",
-    "noise = Noise.BitFlip(probability=0.1)\n",
-    "\n",
-    "print('name: ', noise.name)\n",
-    "print('qubit count: ', noise.qubit_count)\n",
-    "print('Kraus operators: ')\n",
-    "for matrix in noise.to_matrix():\n",
-    "    print(matrix, '\\n')\n"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Other pre-defined noise channels can be used in a similar way:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 6,
    "source": [
     "# define a phase flip noise channel\n",
     "noise = Noise.PhaseFlip(probability=0.1)\n",
@@ -305,21 +303,21 @@
     "noise = Noise.PhaseDamping(gamma=0.1)\n",
     "# define a Pauli noise channel\n",
     "noise = Noise.PauliChannel(probX=0.1, probY=0.2, probZ=0.3)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Defining custom noise channels <a class=\"anchor\" id=\"self-defined\"></a>\n",
     "Apart from the pre-defined noise models, you can also define your own noise model by specifying a list of Kraus operators. The following code shows an example of defining a two-qubit Kraus channel with randomly generated unitary operators."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 7,
    "source": [
     "# creat an arbitrary 2-qubit Kraus matrix\n",
     "E0 = unitary_group.rvs(4) * np.sqrt(0.2) \n",
@@ -328,28 +326,20 @@
     "\n",
     "# define a two-qubit noise channel with Kraus operators\n",
     "noise = Noise.Kraus(K) "
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Note that the noise channel you define needs to form a CPTP map. If the input matrices do not define a CPTP map, an error will be raised."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The input matrices do not define a completely-positive trace-preserving map.\n"
-     ]
-    }
-   ],
+   "execution_count": 8,
    "source": [
     "K_invalid = [np.random.randn(2,2), np.random.randn(2,2)] \n",
     "\n",
@@ -358,11 +348,20 @@
     "    pass\n",
     "except ValueError as err:\n",
     "    print(err)"
-   ]
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "The input matrices do not define a completely-positive trace-preserving map.\n"
+     ]
+    }
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Adding noise to a circuit <a class=\"anchor\" id=\"apply_noise\"></a>\n",
     "\n",
@@ -373,16 +372,21 @@
     "\n",
     "### Build noisy circuits bottom-up  <a class=\"anchor\" id=\"apply_noise_directly\"></a>\n",
     "Noise channels can be applied to the circuit the same way as gates. The following example shows how to apply single- and two-qubit noise channels directly to a circuit. The noise applied can be visualized in the circuit diagram with the `print()` method."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
+   "execution_count": 9,
+   "source": [
+    "# apply depolarizing noise\n",
+    "circ = Circuit().x(0).x(1).cnot(0,1).depolarizing(1, probability=0.2).x(0).two_qubit_dephasing(target1=0, target2=1, probability=0.1)\n",
+    "print(circ)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "T  : |0|     1     |     2     |\n",
       "                                \n",
@@ -394,15 +398,10 @@
      ]
     }
    ],
-   "source": [
-    "# apply depolarizing noise\n",
-    "circ = Circuit().x(0).x(1).cnot(0,1).depolarizing(1, probability=0.2).x(0).two_qubit_dephasing(target1=0, target2=1, probability=0.1)\n",
-    "print(circ)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Applying noise to existing circuits with global methods<a class=\"anchor\" id=\"apply_noise_globally\"></a>\n",
     "\n",
@@ -418,32 +417,41 @@
     "- __target_qubits__: A single or a list of qubit indexes. If not given, noise will be applied to all the qubits in the circuit.\n",
     "\n",
     "When calling the method, the noise channel(s) will be applied right after all `target_gates` in `target_qubits`."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "<div class=\"alert alert-block alert-info\">\n",
     "    <b>Note</b> When you call this method, noise will be inserted right after the gate. If you like to apply more than one noise operation, be aware of the order. Alternatively, you can provide a list of noise operations in one call, and the noise will be applied in forward order. \n",
     "</div>"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "The code below is an example of applying phase damping noise to all gates in the circuit."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
+   "execution_count": 10,
+   "source": [
+    "noise = Noise.PhaseDamping(gamma=0.1)\n",
+    "\n",
+    "# the noise channel is applied to every gate in the circuit\n",
+    "circ = Circuit().x(0).bit_flip(0,0.1).cnot(0,1)\n",
+    "circ.apply_gate_noise(noise)\n",
+    "print('Noise is applied to every gate in the circuit:\\n')\n",
+    "print(circ)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Noise is applied to every gate in the circuit:\n",
       "\n",
@@ -451,32 +459,23 @@
       "                                  \n",
       "q0 : -X-PD(0.1)-BF(0.1)-C-PD(0.1)-\n",
       "                        |         \n",
-      "q2 : -------------------X-PD(0.1)-\n",
+      "q1 : -------------------X-PD(0.1)-\n",
       "\n",
       "T  : |        0        |    1    |\n"
      ]
     }
    ],
-   "source": [
-    "noise = Noise.PhaseDamping(gamma=0.1)\n",
-    "\n",
-    "# the noise channel is applied to every gate in the circuit\n",
-    "circ = Circuit().x(0).bit_flip(0,0.1).cnot(0,2)\n",
-    "circ.apply_gate_noise(noise)\n",
-    "print('Noise is applied to every gate in the circuit:\\n')\n",
-    "print(circ)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "If you want to apply noise to some particular gates in the circuit, you can specify them as `target_gates`. Below is an example in which noise is applied to all X gates in the circuit."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "<div class=\"alert alert-block alert-info\">\n",
     "    <b>Note</b> The <code>target_gates</code> must be a <code>Gate</code> type. You can find all available gates with the following commands:\n",
@@ -487,16 +486,23 @@
     "print(gate_set)\n",
     "</code>\n",
     "</div>"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
+   "execution_count": 11,
+   "source": [
+    "# the noise channel is applied to all the X gates in the circuit\n",
+    "circ = Circuit().x(0).y(1).cnot(0,2).x(1).z(2)\n",
+    "circ.apply_gate_noise(noise, target_gates = Gate.X)\n",
+    "print('Noise is applied to every X gate:\\n')\n",
+    "print(circ)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Noise is applied to every X gate:\n",
       "\n",
@@ -512,29 +518,30 @@
      ]
     }
    ],
-   "source": [
-    "# the noise channel is applied to all the X gates in the circuit\n",
-    "circ = Circuit().x(0).y(1).cnot(0,2).x(1).z(2)\n",
-    "circ.apply_gate_noise(noise, target_gates = Gate.X)\n",
-    "print('Noise is applied to every X gate:\\n')\n",
-    "print(circ)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "If you define custom unitary gates as part of your circuit, and you want to apply noise to them, you can use the `target_unitary` criterion."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
+   "execution_count": 12,
+   "source": [
+    "U1=unitary_group.rvs(4)\n",
+    "U2=unitary_group.rvs(4)\n",
+    "circ = Circuit().x(0).y(1).unitary((0,1),U1).cnot(0,2).x(1).z(2).unitary((1,2),U2)\n",
+    "circ.apply_gate_noise(noise, target_unitary = U2)\n",
+    "print('Noise is applied to U2:\\n')\n",
+    "print(circ)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Noise is applied to U2:\n",
       "\n",
@@ -550,30 +557,29 @@
      ]
     }
    ],
-   "source": [
-    "U1=unitary_group.rvs(4)\n",
-    "U2=unitary_group.rvs(4)\n",
-    "circ = Circuit().x(0).y(1).unitary((0,1),U1).cnot(0,2).x(1).z(2).unitary((1,2),U2)\n",
-    "circ.apply_gate_noise(noise, target_unitary = U2)\n",
-    "print('Noise is applied to U2:\\n')\n",
-    "print(circ)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "If you want to apply noise to some particular qubits in the circuit, you can specify them as `target_qubits`. Below is an example to apply noise to all gates in qubits 0 and 2 in the circuit."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
+   "execution_count": 13,
+   "source": [
+    "# the noise channel is applied to every gate on qubits 0 and 2\n",
+    "circ = Circuit().x(0).y(1).cnot(0,2).x(1).z(2)\n",
+    "circ.apply_gate_noise(noise, target_qubits = [0,2])\n",
+    "print('Noise is applied to every gate in qubits 0 and 2:\\n')\n",
+    "print(circ)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Noise is applied to every gate in qubits 0 and 2:\n",
       "\n",
@@ -589,29 +595,29 @@
      ]
     }
    ],
-   "source": [
-    "# the noise channel is applied to every gate on qubits 0 and 2\n",
-    "circ = Circuit().x(0).y(1).cnot(0,2).x(1).z(2)\n",
-    "circ.apply_gate_noise(noise, target_qubits = [0,2])\n",
-    "print('Noise is applied to every gate in qubits 0 and 2:\\n')\n",
-    "print(circ)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "The `target_qubits` and `target_gates` criteria can be used at the same time. The code block below applies the gate noise to all X gates in qubit 0."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
+   "execution_count": 14,
+   "source": [
+    "# the noise channel is applied to X gate on qubits 0\n",
+    "circ = Circuit().x(0).y(1).cnot(0,2).x(0).x(1).z(2)\n",
+    "circ.apply_gate_noise(noise, target_gates = Gate.X, target_qubits = 0)\n",
+    "print('Noise is applied to X gates in qubits 0:\\n')\n",
+    "print(circ)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Noise is applied to X gates in qubits 0:\n",
       "\n",
@@ -627,29 +633,33 @@
      ]
     }
    ],
-   "source": [
-    "# the noise channel is applied to X gate on qubits 0\n",
-    "circ = Circuit().x(0).y(1).cnot(0,2).x(0).x(1).z(2)\n",
-    "circ.apply_gate_noise(noise, target_gates = Gate.X, target_qubits = 0)\n",
-    "print('Noise is applied to X gates in qubits 0:\\n')\n",
-    "print(circ)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "If a list of noise channels is provided, the first noise channel in the list will be applied first, then the second.  "
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
+   "execution_count": 15,
+   "source": [
+    "# define two noise channels\n",
+    "noise1 = Noise.Depolarizing(probability=0.1)\n",
+    "noise2 = Noise.BitFlip(probability=0.2)\n",
+    "\n",
+    "# apply a list of noise channels \n",
+    "circ = Circuit().x(0).y(1).cnot(0,2).x(1).z(2)\n",
+    "circ.apply_gate_noise([noise1, noise2], target_qubits = [0,1])\n",
+    "print('Noise channels are applied to every gate in qubits 0 and 1:\\n')\n",
+    "print(circ)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Noise channels are applied to every gate in qubits 0 and 1:\n",
       "\n",
@@ -665,33 +675,32 @@
      ]
     }
    ],
-   "source": [
-    "# define two noise channels\n",
-    "noise1 = Noise.Depolarizing(probability=0.1)\n",
-    "noise2 = Noise.BitFlip(probability=0.2)\n",
-    "\n",
-    "# apply a list of noise channels \n",
-    "circ = Circuit().x(0).y(1).cnot(0,2).x(1).z(2)\n",
-    "circ.apply_gate_noise([noise1, noise2], target_qubits = [0,1])\n",
-    "print('Noise channels are applied to every gate in qubits 0 and 1:\\n')\n",
-    "print(circ)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "If you want to apply multi-qubit noise channels to a gate, the number of qubits associated with the gate must equal to the number of qubits defined by the noise channel, or otherwise the noise will not be applied. Below shows an example."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
+   "execution_count": 16,
+   "source": [
+    "# define a two-qubit noise channel\n",
+    "noise = Noise.TwoQubitDephasing(probability=0.1)\n",
+    "\n",
+    "# apply the noise to the circuit\n",
+    "circ = Circuit().x(0).y(1).cnot(0,2).x(1).z(2).swap(1,0)\n",
+    "circ.apply_gate_noise(noise)\n",
+    "print('The two-qubit noise channel is applied to all the two-qubit gates in the circuit:\\n')\n",
+    "print(circ)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "The two-qubit noise channel is applied to all the two-qubit gates in the circuit:\n",
       "\n",
@@ -707,20 +716,10 @@
      ]
     }
    ],
-   "source": [
-    "# define a two-qubit noise channel\n",
-    "noise = Noise.TwoQubitDephasing(probability=0.1)\n",
-    "\n",
-    "# apply the noise to the circuit\n",
-    "circ = Circuit().x(0).y(1).cnot(0,2).x(1).z(2).swap(1,0)\n",
-    "circ.apply_gate_noise(noise)\n",
-    "print('The two-qubit noise channel is applied to all the two-qubit gates in the circuit:\\n')\n",
-    "print(circ)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "#### Applying initialization noise to the circuit <a class=\"anchor\" id=\"initialization-noise\"></a>\n",
     "\n",
@@ -730,25 +729,35 @@
     "- __target_qubits__: a single or a list of qubit indexes. If not given, noise will be applied to all the qubits in the circuit.\n",
     "\n",
     "If you want to apply the initialization noise to an empty circuit, you need to provide `target_qubits` to the method. "
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "<div class=\"alert alert-block alert-info\">\n",
     "    <b>Note</b> When you call this method, noise will be inserted at the very beginning of the circuit. If you like to apply more than one noise operation, be aware of the order. Alternatively, you can provide a list of noise operations in one call, and the noise will be applied in forward order. \n",
     "</div>"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
+   "execution_count": 17,
+   "source": [
+    "# define a noise channel\n",
+    "noise = Noise.Depolarizing(probability=0.1)\n",
+    "\n",
+    "# the noise channel is applied as the initialization noise to the circuit\n",
+    "circ = Circuit().x(0).y(1).cnot(0,2).x(1).z(2)\n",
+    "circ.apply_initialization_noise(noise)\n",
+    "print('Initialization noise is applied to the circuit:\\n')\n",
+    "print(circ)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Initialization noise is applied to the circuit:\n",
       "\n",
@@ -764,32 +773,32 @@
      ]
     }
    ],
-   "source": [
-    "# define a noise channel\n",
-    "noise = Noise.Depolarizing(probability=0.1)\n",
-    "\n",
-    "# the noise channel is applied as the initialization noise to the circuit\n",
-    "circ = Circuit().x(0).y(1).cnot(0,2).x(1).z(2)\n",
-    "circ.apply_initialization_noise(noise)\n",
-    "print('Initialization noise is applied to the circuit:\\n')\n",
-    "print(circ)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "If you want to apply a multi-qubit noise channel as the initialization noise to a circuit and if the number of the qubits in the existing circuit doesn't match the number of qubits as defined by the noise channel, you need to provide `target_qubits` with the number of qubits matching the noise channel. "
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
+   "execution_count": 18,
+   "source": [
+    "# define a two-qubit noise channel\n",
+    "noise = Noise.TwoQubitDephasing(probability=0.1)\n",
+    "\n",
+    "# the noise channel is applied as the initialization noise to the circuit\n",
+    "circ = Circuit().x(0).y(1).cnot(0,1).x(1).z(0)\n",
+    "circ.apply_initialization_noise(noise)\n",
+    "print('Initialization noise is applied to the circuit:\\n')\n",
+    "print(circ)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Initialization noise is applied to the circuit:\n",
       "\n",
@@ -803,20 +812,10 @@
      ]
     }
    ],
-   "source": [
-    "# define a two-qubit noise channel\n",
-    "noise = Noise.TwoQubitDephasing(probability=0.1)\n",
-    "\n",
-    "# the noise channel is applied as the initialization noise to the circuit\n",
-    "circ = Circuit().x(0).y(1).cnot(0,1).x(1).z(0)\n",
-    "circ.apply_initialization_noise(noise)\n",
-    "print('Initialization noise is applied to the circuit:\\n')\n",
-    "print(circ)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "#### Applying readout noise to the circuit <a class=\"anchor\" id=\"readout-noise\"></a>\n",
     "\n",
@@ -826,25 +825,35 @@
     "- __target_qubits__: a single or a list of qubit indexes. If not given, noise will be applied to all the qubits in the circuit.\n",
     "\n",
     "If you want to apply the readout noise to an empty circuit, you need to provide `target_qubits` to the method. "
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "<div class=\"alert alert-block alert-info\">\n",
     "    <b>Note</b> When you call this method, noise will be inserted at the very end of the circuit. If you like to apply more than one noise operation, be aware of the order. You can also provide a list of noise operations in the one call, and the noise will be applied in forward order. \n",
     "</div>"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
+   "execution_count": 19,
+   "source": [
+    "# define a noise channel\n",
+    "noise = Noise.Depolarizing(probability=0.1)\n",
+    "\n",
+    "# the noise channel is applied as the readout noise to the circuit\n",
+    "circ = Circuit().x(0).y(1).cnot(0,2).x(1).z(2)\n",
+    "circ.apply_readout_noise(noise)\n",
+    "print('Read-out noise is applied to the circuit:\\n')\n",
+    "print(circ)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Read-out noise is applied to the circuit:\n",
       "\n",
@@ -860,40 +869,40 @@
      ]
     }
    ],
-   "source": [
-    "# define a noise channel\n",
-    "noise = Noise.Depolarizing(probability=0.1)\n",
-    "\n",
-    "# the noise channel is applied as the readout noise to the circuit\n",
-    "circ = Circuit().x(0).y(1).cnot(0,2).x(1).z(2)\n",
-    "circ.apply_readout_noise(noise)\n",
-    "print('Read-out noise is applied to the circuit:\\n')\n",
-    "print(circ)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "If you want to apply a multi-qubit noise channel as the readout noise to a circuit and if the number of the qubits in the existing circuit doesn't match the number of qubits as defined by the noise channel, you need to provide `target_qubits` with the number of qubits matching the noise channel. "
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Using both the direct and global methods to apply noise <a class=\"anchor\" id=\"both\"></a>\n",
     "You can apply noise to the circuit using both the direct and global methods. "
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
+   "execution_count": 20,
+   "source": [
+    "# define a noise channel\n",
+    "noise = Noise.PhaseFlip(probability=0.2)\n",
+    "\n",
+    "# create a circuit and add noise directly to the circuit\n",
+    "circ = Circuit().x(0).y(1).bit_flip(0,0.1).cnot(1,2).two_qubit_depolarizing(1, 2, probability=0.1).z(2)\n",
+    "circ.apply_gate_noise(noise, target_qubits=0)\n",
+    "print('Noise channels are applied to the circuit:\\n')\n",
+    "print(circ)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Noise channels are applied to the circuit:\n",
       "\n",
@@ -909,20 +918,10 @@
      ]
     }
    ],
-   "source": [
-    "# define a noise channel\n",
-    "noise = Noise.PhaseFlip(probability=0.2)\n",
-    "\n",
-    "# create a circuit and add noise directly to the circuit\n",
-    "circ = Circuit().x(0).y(1).bit_flip(0,0.1).cnot(1,2).two_qubit_depolarizing(1, 2, probability=0.1).z(2)\n",
-    "circ.apply_gate_noise(noise, target_qubits=0)\n",
-    "print('Noise channels are applied to the circuit:\\n')\n",
-    "print(circ)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Running a noisy circuit <a class=\"anchor\" id=\"run\"></a>\n",
     "\n",
@@ -931,38 +930,12 @@
     "With shots = 0, you can obtain the exact values of probability, density matrix and expectation values of the mixed state by attaching the corresponding result type. The reduced density matrix is also available if providing the targets qubits. If no target qubit is provided, the full density matrix will be returned. \n",
     "\n",
     "An example is shown in the code block below."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "T  : |    0    |    1    |    2    |              Result Types              |\n",
-      "                                                                             \n",
-      "q0 : -X-AD(0.1)-C-AD(0.1)-----------Probability-Expectation(Z)-DensityMatrix-\n",
-      "                |                   |                          |             \n",
-      "q1 : -Y---------|-X-----------------Probability----------------DensityMatrix-\n",
-      "                |                   |                                        \n",
-      "q2 : -----------X-AD(0.1)-Z-AD(0.1)-Probability------------------------------\n",
-      "\n",
-      "T  : |    0    |    1    |    2    |              Result Types              |\n",
-      "- Probability is: \n",
-      "[0.1171 0.0729 0.     0.     0.1539 0.6561 0.     0.    ]\n",
-      "- Expectation value <Z_0> is: \n",
-      "-0.6199999999999997\n",
-      "- The reduced Density Matrix is: \n",
-      "[[0.19+0.j 0.  +0.j 0.  +0.j 0.  +0.j]\n",
-      " [0.  +0.j 0.  +0.j 0.  +0.j 0.  +0.j]\n",
-      " [0.  +0.j 0.  +0.j 0.81+0.j 0.  +0.j]\n",
-      " [0.  +0.j 0.  +0.j 0.  +0.j 0.  +0.j]]\n"
-     ]
-    }
-   ],
+   "execution_count": 21,
    "source": [
     "# define the noise channel\n",
     "noise = Noise.AmplitudeDamping(gamma=0.1)\n",
@@ -991,42 +964,47 @@
     "print(result.values[1])\n",
     "print('- The reduced Density Matrix is: ')\n",
     "print(result.values[2])"
-   ]
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "T  : |    0    |    1    |    2    |              Result Types              |\n",
+      "                                                                             \n",
+      "q0 : -X-AD(0.1)-C-AD(0.1)-----------Probability-Expectation(Z)-DensityMatrix-\n",
+      "                |                   |                          |             \n",
+      "q1 : -Y---------|-X-----------------Probability----------------DensityMatrix-\n",
+      "                |                   |                                        \n",
+      "q2 : -----------X-AD(0.1)-Z-AD(0.1)-Probability------------------------------\n",
+      "\n",
+      "T  : |    0    |    1    |    2    |              Result Types              |\n",
+      "- Probability is: \n",
+      "[0.1171 0.0729 0.     0.     0.1539 0.6561 0.     0.    ]\n",
+      "- Expectation value <Z_0> is: \n",
+      "-0.6199999999999997\n",
+      "- The reduced Density Matrix is: \n",
+      "[[0.19+0.j 0.  +0.j 0.  +0.j 0.  +0.j]\n",
+      " [0.  +0.j 0.  +0.j 0.  +0.j 0.  +0.j]\n",
+      " [0.  +0.j 0.  +0.j 0.81+0.j 0.  +0.j]\n",
+      " [0.  +0.j 0.  +0.j 0.  +0.j 0.  +0.j]]\n"
+     ]
+    }
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "With shots > 0, the results are sampled from the probability distributions. The result type `density_matrix` is not available for shots > 0. \n",
     "\n",
     "The code below shows the expectation value $\\langle Z_0\\rangle$ and the probability that the mixed state collapsing into different states. We see those values here are different from the exact values obtained in the shots = 0 case."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "T  : |    0    |    1    |    2    |       Result Types       |\n",
-      "                                                               \n",
-      "q0 : -X-AD(0.1)-C-AD(0.1)-----------Probability-Expectation(Z)-\n",
-      "                |                   |                          \n",
-      "q1 : -Y---------|-X-----------------Probability----------------\n",
-      "                |                   |                          \n",
-      "q2 : -----------X-AD(0.1)-Z-AD(0.1)-Probability----------------\n",
-      "\n",
-      "T  : |    0    |    1    |    2    |       Result Types       |\n",
-      "- Probability is: \n",
-      "[0.08 0.07 0.   0.   0.21 0.64 0.   0.  ]\n",
-      "- Expectation value <Z_0> is: \n",
-      "-0.7\n"
-     ]
-    }
-   ],
+   "execution_count": 22,
    "source": [
     "# create a circuit\n",
     "circ = Circuit().x(0).y(1).cnot(0,2).x(1).z(2)\n",
@@ -1044,22 +1022,43 @@
     "print(result.values[0])\n",
     "print('- Expectation value <Z_0> is: ')\n",
     "print(result.values[1])"
-   ]
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "T  : |    0    |    1    |    2    |       Result Types       |\n",
+      "                                                               \n",
+      "q0 : -X-AD(0.1)-C-AD(0.1)-----------Probability-Expectation(Z)-\n",
+      "                |                   |                          \n",
+      "q1 : -Y---------|-X-----------------Probability----------------\n",
+      "                |                   |                          \n",
+      "q2 : -----------X-AD(0.1)-Z-AD(0.1)-Probability----------------\n",
+      "\n",
+      "T  : |    0    |    1    |    2    |       Result Types       |\n",
+      "- Probability is: \n",
+      "[0.08 0.05 0.   0.   0.2  0.67 0.   0.  ]\n",
+      "- Expectation value <Z_0> is: \n",
+      "-0.74\n"
+     ]
+    }
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Reference\n",
     "[1] Srikanth R, Banerjee S. \"Squeezed generalized amplitude damping channel\", Physical Review A, 2008, 77(1): 012318."
-   ]
+   ],
+   "metadata": {}
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
+   "name": "python3",
+   "display_name": "Python 3.7.6 64-bit ('base': conda)"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1071,7 +1070,10 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.6"
+  },
+  "interpreter": {
+   "hash": "0253d37730c9ef949b31486b4cff0d658c43b30ac02c14841de7d7631b67ad05"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

One of the examples in Simulating_Noise_On_Amazon_Braket.ipynb uses non-contiguous qubit indices, and the resulting circuit cannot actually be run on any device. This commit fixes the example to have contiguous qubits.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
