### PR TITLE
Adding device = AwsDevice("arn:aws:braket:::device/qpu/d-wave/Advanta…

### DIFF
--- a/examples/braket_features/Getting_Devices_and_Checking_Device_Properties.ipynb
+++ b/examples/braket_features/Getting_Devices_and_Checking_Device_Properties.ipynb
@@ -143,7 +143,7 @@
     }
    ],
    "source": [
-    "# for example, the following name refers to the DWave Advantage system.\n",
+    "# for example, the following name refers to a DWave Advantage system.\n",
     "AwsDevice.get_devices(names=['Advantage_system1.1'])"
    ]
   },

--- a/examples/quantum_annealing/Dwave_StructuralImbalance/Dwave_StructuralImbalance.ipynb
+++ b/examples/quantum_annealing/Dwave_StructuralImbalance/Dwave_StructuralImbalance.ipynb
@@ -151,6 +151,7 @@
    "source": [
     "# session and device\n",
     "device = AwsDevice(\"arn:aws:braket:::device/qpu/d-wave/Advantage_system1\")\n",
+    "# device = AwsDevice(\"arn:aws:braket:::device/qpu/d-wave/Advantage_system4\")\n",
     "print('Device:', device)"
    ]
   },

--- a/examples/quantum_annealing/Running_large_problems_using_QBSolv.ipynb
+++ b/examples/quantum_annealing/Running_large_problems_using_QBSolv.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To solve a problem with a D-Wave QPU, one defines the problem in QUBO (or Ising) form. Owing to the limited qubit connectivity in D-Wave devices, the source graph given by the QUBO (or Ising) problem must be mapped to the target graph of the underlying hardware following a process called minor embedding. For the D-Wave 2000Q device with a Chimera graph, there is no guarantee to find an embedding for a problem with more than 64 variables; for the Advantage device with a Pegasus graph, the upper limit for an arbitrary problem is around 145. However, some real-world problems may require more variables than a QPU can support. To solve large problems with the D-Wave devices, you can use `QBSolv()`, which is offered by the Ocean SDK. \n",
+    "To solve a problem with a D-Wave QPU, one defines the problem in QUBO (or Ising) form. Owing to the limited qubit connectivity in D-Wave devices, the source graph given by the QUBO (or Ising) problem must be mapped to the target graph of the underlying hardware following a process called minor embedding. For the D-Wave 2000Q device with a Chimera graph, there is no guarantee to find an embedding for a problem with more than 64 variables; for the Advantage devices with a Pegasus graph, the upper limit for an arbitrary problem is around 145. However, some real-world problems may require more variables than a QPU can support. To solve large problems with the D-Wave devices, you can use `QBSolv()`, which is offered by the Ocean SDK.\n",
     "\n",
     "`QBSolv()` is a hybrid solver that can decompose large QUBO problems into sub-problems. The sub-problems are solved using either both the QPU and a classical Tabu solver, or the classical solver alone. The solution to the problem is then constructed by the results of the sub-problems. More details can be found in the D-Wave documentation [here](https://docs.ocean.dwavesys.com/projects/qbsolv/en/latest/).\n",
     "\n",
@@ -116,8 +116,9 @@
     "# define size of the sub-problems\n",
     "solver_limit = 40\n",
     "\n",
-    "# choose the D-Wave Advantage system\n",
-    "system = BraketDWaveSampler(s3_folder, 'arn:aws:braket:::device/qpu/d-wave/Advantage_system1')"
+    "# choose a D-Wave Advantage system\n",
+    "system = BraketDWaveSampler(s3_folder, 'arn:aws:braket:::device/qpu/d-wave/Advantage_system1')\n",
+    "# system = BraketDWaveSampler(s3_folder, 'arn:aws:braket:::device/qpu/d-wave/Advantage_system4')"
    ]
   },
   {


### PR DESCRIPTION
…ge_system4") to the relevant example notebooks.

*Issue #, if available:* None

*Description of changes:* Updating examples to include the new Advantage 4.1 solver


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
