### PR TITLE
Update PennyLane QAOA notebook to use new expval

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -37,7 +37,7 @@ dependencies:
       - jax==0.2.12
       - keras==2.4.0
       - openfermion==1.0.0
-      - pennylane==0.16
+      - pennylane==0.17
       - pennylane-qchem==0.16
       - tensorflow==2.4.1
       - torch==1.8.1

--- a/examples/pennylane/2_Graph_optimization_with_QAOA.ipynb
+++ b/examples/pennylane/2_Graph_optimization_with_QAOA.ipynb
@@ -76,6 +76,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<b>Note</b> This notebook requires PennyLane version 0.17 or above.\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## QAOA"
    ]
   },
@@ -232,7 +241,6 @@
     "wires = n_nodes\n",
     "\n",
     "def circuit(params, **kwargs):\n",
-    "    \n",
     "    for i in range(wires):  # Prepare an equal superposition over all qubits\n",
     "        qml.Hadamard(wires=i)\n",
     "        \n",
@@ -307,7 +315,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cost_function = qml.ExpvalCost(circuit, cost_h, dev, optimize=True)"
+    "@qml.qnode(dev)\n",
+    "def cost_function(params, **kwargs):\n",
+    "    circuit(params)\n",
+    "    return qml.expval(cost_h)"
    ]
   },
   {
@@ -637,12 +648,13 @@
    "source": [
     "n_layers = 2\n",
     "\n",
-    "def circuit(params, **kwargs):\n",
-    "    \n",
+    "@qml.qnode(dev)\n",
+    "def cost_function(params, **kwargs):\n",
     "    for i in range(wires):  # Prepare an equal superposition over all qubits\n",
     "        qml.Hadamard(wires=i)\n",
     "        \n",
-    "    qml.layer(qaoa_layer, n_layers, params[0], params[1])"
+    "    qml.layer(qaoa_layer, n_layers, params[0], params[1])\n",
+    "    return qml.expval(cost_h)"
    ]
   },
   {
@@ -656,15 +668,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cost_function = qml.ExpvalCost(circuit, cost_h, dev, optimize=True)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -673,7 +676,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -693,7 +696,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -773,7 +776,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
…ctations

*Issue #, if available:*

*Description of changes:*
There's a new method for computing Hamiltonian expectations in PennyLane in 0.17 (see https://pennylane.readthedocs.io/en/stable/development/release_notes.html#release-0-17-0) using just `qml.expval`. This PR switches the PennyLane QAOA notebook to use that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
