### PR TITLE
fix: Handle Rigetti tests, update dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,10 +4,11 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - awscli=1.18.121
-  - boto3=1.14.43
-  - botocore=1.17.44
+  - awscli=1.20.52
+  - boto3=1.18.52
+  - botocore=1.21.52
   - conda-pack=0.6.0
+  - colorama=0.4.3
   - decorator=4.4.0
   - idna=2.10
   - ipykernel=5.3.4
@@ -19,13 +20,14 @@ dependencies:
   - numpy=1.19.2
   - openbabel=3.1.1
   - pandas=1.1.4
-  - pip=21.1.1
+  - pip
   - protobuf=3.12.4
   - psi4=1.3.2
-  - pydantic=1.7.3
-  - python=3.7.10
+  - python=3.7
   - rsa=4.4.1
   - scipy=1.5.2
+  - six=1.15.0
+  - typing_extensions=3.7.4.3
   - pip:
       - amazon-braket-default-simulator
       - amazon-braket-ocean-plugin
@@ -34,10 +36,11 @@ dependencies:
       - amazon-braket-sdk
       - dask==2.30.0
       - dwave-ocean-sdk==3.3.0
-      - jax==0.2.12
-      - keras==2.4.0
+      - jax==0.2.21
+      - keras==2.6.0
       - openfermion==1.0.0
-      - pennylane==0.17
-      - pennylane-qchem==0.16
-      - tensorflow==2.4.1
+      - pennylane==0.18
+      - pennylane-qchem==0.17
+      - s3transfer==0.5.0
+      - tensorflow==2.6.0
       - torch==1.8.1

--- a/test/notebook_tests/test_notebooks.py
+++ b/test/notebook_tests/test_notebooks.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+import datetime
 import fileinput
 import logging
 import os
@@ -31,13 +32,32 @@ _EXCLUSIVE_DEVICE_REGIONS = {
 test_path = "examples/"
 test_notebooks = []
 
+CURRENT_UTC = datetime.datetime.utcnow()
+CURRENT_TIME = CURRENT_UTC.time().strftime("%H:%M:%S")
+
+# Currently adding rigetti notebooks to skip as files, since other notebook files also have rigetti arn.
+RIGETTI_NOTEBOOKS = [
+    "2_Running_quantum_circuits_on_QPU_devices.ipynb",
+    "Allocating_Qubits_on_QPU_Devices.ipynb",
+    "Verbatim_Compilation.ipynb",
+]
+
+
+def _rigetti_availability(file_name):
+    rigetti_start_time = str(datetime.time(15, 0))
+    rigetti_end_time = str(datetime.time(19, 0))
+    is_within_time_window = rigetti_start_time < CURRENT_TIME < rigetti_end_time
+    if file_name in RIGETTI_NOTEBOOKS and not is_within_time_window:
+        return False
+    return True
+
 
 for dir_, _, files in os.walk(test_path):
     for file_name in files:
         rel_file = os.path.join(dir_, file_name)
         if file_name.endswith("copy.ipynb"):
             os.remove(rel_file)
-        if file_name.endswith(".ipynb") and "QPU" not in file_name:
+        if file_name.endswith(".ipynb") and _rigetti_availability(file_name):
             test_notebooks.append((dir_, rel_file))
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Test rigetti notebooks if they are within the device availability window. Currently we are not skipping those tests based on rigetti arn but on file_name, since some notebook files contain rigetti arn just for checking device status. 
- Updated dependencies to allow user to run notebook tests locally using pytest and keep dependencies in sync with NBI. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
