### PR TITLE
Pin PySCF to version < 2.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -41,6 +41,7 @@ dependencies:
       - openfermion==1.0.0
       - pennylane==0.18
       - pennylane-qchem==0.17
+      - pyscf>=1.7.2,<2.0
       - s3transfer==0.5.0
       - tensorflow==2.6.0
       - torch==1.8.1


### PR DESCRIPTION
PySCF 2.0 is incompatible with PennyLane-Qchem:

https://github.com/PennyLaneAI/pennylane/pull/1827

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
