### PR TITLE
fix: jobs model dependencies, excluded job examples from tests

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,9 +4,9 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - awscli=1.20.52
-  - boto3=1.18.52
-  - botocore=1.21.52
+  - awscli=1.22.6
+  - boto3=1.20.6
+  - botocore=1.23.6
   - conda-pack=0.6.0
   - colorama=0.4.3
   - decorator=4.4.0

--- a/test/notebook_tests/test_notebooks.py
+++ b/test/notebook_tests/test_notebooks.py
@@ -26,7 +26,10 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 _EXCLUSIVE_DEVICE_REGIONS = {
-    "arn:aws:braket:::device/quantum-simulator/amazon/tn1": ["us-west-2", "us-east-1",],
+    "arn:aws:braket:::device/quantum-simulator/amazon/tn1": [
+        "us-west-2",
+        "us-east-1",
+    ],
 }
 
 test_path = "examples/"
@@ -36,10 +39,12 @@ CURRENT_UTC = datetime.datetime.utcnow()
 CURRENT_TIME = CURRENT_UTC.time().strftime("%H:%M:%S")
 
 # Currently adding rigetti notebooks to skip as files, since other notebook files also have rigetti arn.
-RIGETTI_NOTEBOOKS = [
+EXCLUDED_NOTEBOOKS = [
     "2_Running_quantum_circuits_on_QPU_devices.ipynb",
     "Allocating_Qubits_on_QPU_Devices.ipynb",
     "Verbatim_Compilation.ipynb",
+    "Hyperparameter_tuning.ipynb",
+    "bring_your_own_container.ipynb",
 ]
 
 
@@ -47,7 +52,7 @@ def _rigetti_availability(file_name):
     rigetti_start_time = str(datetime.time(15, 0))
     rigetti_end_time = str(datetime.time(19, 0))
     is_within_time_window = rigetti_start_time < CURRENT_TIME < rigetti_end_time
-    if file_name in RIGETTI_NOTEBOOKS and not is_within_time_window:
+    if file_name in EXCLUDED_NOTEBOOKS and not is_within_time_window:
         return False
     return True
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Jobs model configuration changes are added by updating the required packages in environment file. 
- Hyperparameter tuning notebook excluded from tests since it overlaps with PL example. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
