### PR TITLE
fix: metrics timeout issue in hybrid PL notebook

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,9 +4,6 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - awscli=1.22.6
-  - boto3=1.20.6
-  - botocore=1.23.6
   - conda-pack=0.6.0
   - colorama=0.4.3
   - decorator=4.4.0
@@ -29,6 +26,9 @@ dependencies:
   - six=1.15.0
   - typing_extensions=3.7.4.3
   - pip:
+      - awscli==1.22.17
+      - botocore==1.23.17
+      - boto3==1.20.17
       - amazon-braket-default-simulator
       - amazon-braket-ocean-plugin
       - amazon-braket-pennylane-plugin

--- a/examples/hybrid_jobs/2_Using_PennyLane_with_Braket_Jobs/Using_PennyLane_with_Braket_Jobs.ipynb
+++ b/examples/hybrid_jobs/2_Using_PennyLane_with_Braket_Jobs/Using_PennyLane_with_Braket_Jobs.ipynb
@@ -311,12 +311,16 @@
     "import pandas as pd\n",
     "from matplotlib.ticker import MaxNLocator\n",
     "\n",
+    "metrics_data = job.metrics()\n",
     "\n",
-    "df = pd.DataFrame(job.metrics())\n",
+    "if metrics_data: \n",
+    "    df = pd.DataFrame(job.metrics())\n",
     "\n",
-    "ax = plt.figure().gca()\n",
-    "ax.xaxis.set_major_locator(MaxNLocator(integer=True))\n",
-    "figure = df.plot(x=\"iteration_number\", y=\"Cost\", ax=ax)"
+    "    ax = plt.figure().gca()\n",
+    "    ax.xaxis.set_major_locator(MaxNLocator(integer=True))\n",
+    "    figure = df.plot(x=\"iteration_number\", y=\"Cost\", ax=ax)\n",
+    "else:\n",
+    "    print(\"Wait for metrics to populate and re-run the cell.\")"
    ]
   },
   {
@@ -524,11 +528,16 @@
     }
    ],
    "source": [
-    "df = pd.DataFrame(continued_job.metrics())\n",
+    "metrics_data = continued_job.metrics()\n",
     "\n",
-    "ax = plt.figure().gca()\n",
-    "ax.xaxis.set_major_locator(MaxNLocator(integer=True))\n",
-    "figure = df.plot(x=\"iteration_number\", y=\"Cost\", ax=ax)"
+    "if metrics_data: \n",
+    "    df = pd.DataFrame(continued_job.metrics())\n",
+    "\n",
+    "    ax = plt.figure().gca()\n",
+    "    ax.xaxis.set_major_locator(MaxNLocator(integer=True))\n",
+    "    figure = df.plot(x=\"iteration_number\", y=\"Cost\", ax=ax)\n",
+    "else: \n",
+    "    print(\"Wait for metrics to populate and re-run the cell.\")"
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When running all the cells for notebook at once, it fails at the last cell with KeyError for iteration since metrics are generated within allocated time. Handled the case using if-else statements to address this issue and allow users to re-run the cell when metrics not populated. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
