### PR TITLE
Clean-up example notebooks after introduction of S3 simplification

### DIFF
--- a/examples/advanced_circuits_algorithms/Grover/Grover.ipynb
+++ b/examples/advanced_circuits_algorithms/Grover/Grover.ipynb
@@ -202,13 +202,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "__NOTE__: If you are working with the local simulator ```LocalSimulator()``` you do not need to specify any S3 location. However, if you are using a managed device or any QPU devices you need to specify the S3 location where your results will be stored. Remember that bucket names for Amazon Braket always begin with `\"amazon-braket-\"`. In this case, you must replace the API call ```device.run(circuit, ...)``` below with ```device.run(circuit, s3_folder, ...)```, where `s3_folder = (my_bucket, my_prefix)`. If you don't specify the S3 location, default S3 folder, where all inputs and outputs for your tasks are saved, follows the convention `amazon-braket-<region>-<account number>`. "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Helper Functions <a name=\"wrappers\"></a>"
    ]
   },
@@ -342,9 +335,6 @@
     "    circ.probability()\n",
     "\n",
     "    # submit task: define task (asynchronous)\n",
-    "    if device.name == 'DefaultSimulator':\n",
-    "        task = device.run(circ, shots=1000)\n",
-    "    else:\n",
     "        task = device.run(circ, shots=1000)\n",
     "\n",
     "    # Get ID of submitted task\n",

--- a/examples/advanced_circuits_algorithms/QAA/QAA_tutorial.ipynb
+++ b/examples/advanced_circuits_algorithms/QAA/QAA_tutorial.ipynb
@@ -286,7 +286,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## IMPLEMENTATION OF RELECTION OPERATORS"
+    "## IMPLEMENTATION OF REFLECTION OPERATORS"
    ]
   },
   {
@@ -427,7 +427,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## VISUALIZATION OF THE CIRCUIT FOR THE RELECTION $\\mathcal{R}_{0}$"
+    "## VISUALIZATION OF THE CIRCUIT FOR THE REFLECTION $\\mathcal{R}_{0}$"
    ]
   },
   {

--- a/examples/advanced_circuits_algorithms/QAA/QAA_tutorial.ipynb
+++ b/examples/advanced_circuits_algorithms/QAA/QAA_tutorial.ipynb
@@ -273,13 +273,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "__NOTE__: If you are working with the local simulator ```LocalSimulator()``` you do not need to specify any S3 location. However, if you are using a managed device or any QPU devices you need to specify the S3 location where your results will be stored. Remember that bucket names for Amazon Braket always begin with `\"amazon-braket-\"`. In this case, you must replace the API call ```device.run(circuit, ...)``` below with ```device.run(circuit, s3_folder, ...)```, where `s3_folder = (my_bucket, my_prefix)`. If you don't specify the S3 location, default S3 folder, where all inputs and outputs for your tasks are saved, follows the convention `amazon-braket-<region>-<account number>`. "
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {},

--- a/examples/advanced_circuits_algorithms/QFT/QFT.ipynb
+++ b/examples/advanced_circuits_algorithms/QFT/QFT.ipynb
@@ -180,13 +180,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "__NOTE__: If you are working with the local simulator ```LocalSimulator()``` you do not need to specify any S3 location. However, if you are using a managed device or any QPU devices you need to specify the S3 location where your results will be stored. Remember that bucket names for Amazon Braket always begin with `\"amazon-braket-\"`. In this case, you must replace the API call ```device.run(circuit, ...)``` below with ```device.run(circuit, s3_folder, ...)```, where `s3_folder = (my_bucket, my_prefix)`. If you don't specify the S3 location, default S3 folder, where all inputs and outputs for your tasks are saved, follows the convention `amazon-braket-<region>-<account number>`. "
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {},

--- a/examples/advanced_circuits_algorithms/QPE/QPE.ipynb
+++ b/examples/advanced_circuits_algorithms/QPE/QPE.ipynb
@@ -207,13 +207,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "__NOTE__: If you are working with the local simulator ```LocalSimulator()``` you do not need to specify any S3 location. However, if you are using a managed device or any QPU devices you need to specify the S3 location where your results will be stored. Remember that bucket names for Amazon Braket always begin with `\"amazon-braket-\"`. In this case, you must replace the API call ```device.run(circuit, ...)``` below with ```device.run(circuit, s3_folder, ...)```, where `s3_folder = (my_bucket, my_prefix)`. If you don't specify the S3 location, default S3 folder, where all inputs and outputs for your tasks are saved, follows the convention `amazon-braket-<region>-<account number>`. "
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {},

--- a/examples/advanced_circuits_algorithms/Randomness/Randomness_Generation.ipynb
+++ b/examples/advanced_circuits_algorithms/Randomness/Randomness_Generation.ipynb
@@ -72,13 +72,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "__NOTE__: If you are working with the local simulator ```LocalSimulator()``` you do not need to specify any S3 location. However, if you are using a managed device or any QPU devices you need to specify the S3 location where your results will be stored. Remember that bucket names for Amazon Braket always begin with `\"amazon-braket-\"`. In this case, you must replace the API call ```device.run(circuit, ...)``` below with ```device.run(circuit, s3_folder, ...)```, where `s3_folder = (my_bucket, my_prefix)`. If you don't specify the S3 location, default S3 folder, where all inputs and outputs for your tasks are saved, follows the convention `amazon-braket-<region>-<account number>`. "
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},

--- a/examples/braket_features/Allocating_Qubits_on_QPU_Devices.ipynb
+++ b/examples/braket_features/Allocating_Qubits_on_QPU_Devices.ipynb
@@ -28,13 +28,6 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "__NOTE__: If you are working with the local simulator ```LocalSimulator()``` you do not need to specify any S3 location. However, if you are using a managed device or any QPU devices you need to specify the S3 location where your results will be stored. Remember that bucket names for Amazon Braket always begin with `\"amazon-braket-\"`. In this case, you must replace the API call ```device.run(circuit, ...)``` below with ```device.run(circuit, s3_folder, ...)```, where `s3_folder = (my_bucket, my_prefix)`. If you don't specify the S3 location, default S3 folder, where all inputs and outputs for your tasks are saved, follows the convention `amazon-braket-<region>-<account number>`. "
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "metadata": {
     "pycharm": {
      "name": "#%% md\n"

--- a/examples/braket_features/Simulating_Noise_On_Amazon_Braket.ipynb
+++ b/examples/braket_features/Simulating_Noise_On_Amazon_Braket.ipynb
@@ -79,13 +79,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "__NOTE__: If you are working with the local simulator ```LocalSimulator()``` you do not need to specify any S3 location. However, if you are using a managed device or any QPU devices you need to specify the S3 location where your results will be stored. Remember that bucket names for Amazon Braket always begin with `\"amazon-braket-\"`. In this case, you must replace the API call ```device.run(circuit, ...)``` below with ```device.run(circuit, s3_folder, ...)```, where `s3_folder = (my_bucket, my_prefix)`. If you don't specify the S3 location, default S3 folder, where all inputs and outputs for your tasks are saved, follows the convention `amazon-braket-<region>-<account number>`. "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Quick start <a class=\"anchor\" id=\"start\"></a>\n",
     "\n",
     "Let's start with a simple example of running a noisy circuit on Amazon Braket. "

--- a/examples/braket_features/TN1_demo_local_vs_non-local_random_circuits.ipynb
+++ b/examples/braket_features/TN1_demo_local_vs_non-local_random_circuits.ipynb
@@ -17,13 +17,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "__NOTE__: If you are working with the local simulator ```LocalSimulator()``` you do not need to specify any S3 location. However, if you are using a managed device or any QPU devices you need to specify the S3 location where your results will be stored. Remember that bucket names for Amazon Braket always begin with `\"amazon-braket-\"`. In this case, you must replace the API call ```device.run(circuit, ...)``` below with ```device.run(circuit, s3_folder, ...)```, where `s3_folder = (my_bucket, my_prefix)`. If you don't specify the S3 location, default S3 folder, where all inputs and outputs for your tasks are saved, follows the convention `amazon-braket-<region>-<account number>`. "
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},

--- a/examples/braket_features/Verbatim_Compilation.ipynb
+++ b/examples/braket_features/Verbatim_Compilation.ipynb
@@ -37,13 +37,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "__NOTE__: If you are working with the local simulator ```LocalSimulator()``` you do not need to specify any S3 location. However, if you are using a managed device or any QPU devices you need to specify the S3 location where your results will be stored. Remember that bucket names for Amazon Braket always begin with `\"amazon-braket-\"`. In this case, you must replace the API call ```device.run(circuit, ...)``` below with ```device.run(circuit, s3_folder, ...)```, where `s3_folder = (my_bucket, my_prefix)`. If you don't specify the S3 location, default S3 folder, where all inputs and outputs for your tasks are saved, follows the convention `amazon-braket-<region>-<account number>`. \n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Recap: Running circuits on Amazon Braket"
    ]
   },

--- a/examples/getting_started/1_Running_quantum_circuits_on_simulators.ipynb
+++ b/examples/getting_started/1_Running_quantum_circuits_on_simulators.ipynb
@@ -40,13 +40,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "__NOTE__: If you are working with the local simulator ```LocalSimulator()``` you do not need to specify any S3 location. However, if you are using a managed device or any QPU devices you need to specify the S3 location where your results will be stored. Remember that bucket names for Amazon Braket always begin with `\"amazon-braket-\"`. In this case, you must replace the API call ```device.run(circuit, ...)``` below with ```device.run(circuit, s3_folder, ...)```, where `s3_folder = (my_bucket, my_prefix)`. If you don't specify the S3 location, default S3 folder, where all inputs and outputs for your tasks are saved, follows the convention `amazon-braket-<region>-<account number>`. "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Problem: Prepare a GHZ State"
    ]
   },

--- a/examples/getting_started/2_Running_quantum_circuits_on_QPU_devices.ipynb
+++ b/examples/getting_started/2_Running_quantum_circuits_on_QPU_devices.ipynb
@@ -36,13 +36,6 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "__NOTE__: If you are working with the local simulator ```LocalSimulator()``` you do not need to specify any S3 location. However, if you are using a managed device or any QPU devices you need to specify the S3 location where your results will be stored. Remember that bucket names for Amazon Braket always begin with `\"amazon-braket-\"`. In this case, you must replace the API call ```device.run(circuit, ...)``` below with ```device.run(circuit, s3_folder, ...)```, where `s3_folder = (my_bucket, my_prefix)`. If you don't specify the S3 location, default S3 folder, where all inputs and outputs for your tasks are saved, follows the convention `amazon-braket-<region>-<account number>`. "
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "metadata": {
     "pycharm": {
      "name": "#%% md\n"

--- a/examples/getting_started/3_Deep_dive_into_the_anatomy_of_quantum_circuits.ipynb
+++ b/examples/getting_started/3_Deep_dive_into_the_anatomy_of_quantum_circuits.ipynb
@@ -691,13 +691,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "__NOTE__: If you are working with the local simulator ```LocalSimulator()``` you do not need to specify any S3 location. However, if you are using a managed device or any QPU devices you need to specify the S3 location where your results will be stored. Remember that bucket names for Amazon Braket always begin with `\"amazon-braket-\"`. In this case, you must replace the API call ```device.run(circuit, ...)``` below with ```device.run(circuit, s3_folder, ...)```, where `s3_folder = (my_bucket, my_prefix)`. If you don't specify the S3 location, default S3 folder, where all inputs and outputs for your tasks are saved, follows the convention `amazon-braket-<region>-<account number>`. "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "__POLLING PARAMETERS__: With the ```run(...)``` method we can set two important parameters: \n",
     "* ```poll_timeout_seconds``` is the number of seconds you want to wait and poll the task before it times out; the default value is 5 days (that is $\\sim 5*60*60*24$ seconds). \n",
     "* ```poll_interval_seconds``` is the frequency how often the task is polled, e.g., how often you call the Braket API to get the status; the default value is 1 second. "

--- a/examples/getting_started/4_Superdense_coding.ipynb
+++ b/examples/getting_started/4_Superdense_coding.ipynb
@@ -77,7 +77,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Typically, we recommend running circuits with fewer than 25 qubits on the local simulator to avoid latency bottlenecks. The managed, high-performance simulator SV1 is better suited for larger circuits up to 34 qubits. Nevertheless, for demonstration purposes, we are going to continue this example with SV1 but it is easy to switch over to the local simulator by replacing the last line in the cell below with ```device = LocalSimulator()``` and importing the ```LocalSimulator```.\n",
+    "Typically, we recommend running circuits with fewer than 25 qubits on the local simulator to avoid latency bottlenecks. The managed, high-performance simulator SV1 is better suited for larger circuits up to 34 qubits. Nevertheless, for demonstration purposes, we are going to continue this example with SV1 but it is easy to switch over to the local simulator by replacing the last line in the cell below with ```device = LocalSimulator()``` and importing the ```LocalSimulator```.\n"
    ]
   },
   {

--- a/examples/getting_started/4_Superdense_coding.ipynb
+++ b/examples/getting_started/4_Superdense_coding.ipynb
@@ -78,8 +78,6 @@
    "metadata": {},
    "source": [
     "Typically, we recommend running circuits with fewer than 25 qubits on the local simulator to avoid latency bottlenecks. The managed, high-performance simulator SV1 is better suited for larger circuits up to 34 qubits. Nevertheless, for demonstration purposes, we are going to continue this example with SV1 but it is easy to switch over to the local simulator by replacing the last line in the cell below with ```device = LocalSimulator()``` and importing the ```LocalSimulator```.\n",
-    "\n",
-    "__NOTE__: If you are working with the local simulator ```LocalSimulator()``` you do not need to specify any S3 location. However, if you are using a managed device or any QPU devices you need to specify the S3 location where your results will be stored. Remember that bucket names for Amazon Braket always begin with `\"amazon-braket-\"`. In this case, you must replace the API call ```device.run(circuit, ...)``` below with ```device.run(circuit, s3_folder, ...)```, where `s3_folder = (my_bucket, my_prefix)`. If you don't specify the S3 location, default S3 folder, where all inputs and outputs for your tasks are saved, follows the convention `amazon-braket-<region>-<account number>`. "
    ]
   },
   {

--- a/examples/hybrid_quantum_algorithms/QAOA/QAOA_braket.ipynb
+++ b/examples/hybrid_quantum_algorithms/QAOA/QAOA_braket.ipynb
@@ -281,13 +281,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "__NOTE__: If you are working with the local simulator ```LocalSimulator()``` you do not need to specify any S3 location. However, if you are using a managed device or any QPU devices you need to specify the S3 location where your results will be stored. Remember that bucket names for Amazon Braket always begin with `\"amazon-braket-\"`. In this case, you must replace the API call ```device.run(circuit, ...)``` below with ```device.run(circuit, s3_folder, ...)```, where `s3_folder = (my_bucket, my_prefix)`. If you don't specify the S3 location, default S3 folder, where all inputs and outputs for your tasks are saved, follows the convention `amazon-braket-<region>-<account number>`. "
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {},

--- a/examples/hybrid_quantum_algorithms/VQE_Transverse_Ising/VQE_Transverse_Ising_Model.ipynb
+++ b/examples/hybrid_quantum_algorithms/VQE_Transverse_Ising/VQE_Transverse_Ising_Model.ipynb
@@ -154,13 +154,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "__NOTE__: If you are working with the local simulator ```LocalSimulator()``` you do not need to specify any S3 location. However, if you are using a managed device or any QPU devices you need to specify the S3 location where your results will be stored. Remember that bucket names for Amazon Braket always begin with `\"amazon-braket-\"`. In this case, you must replace the API call ```device.run(circuit, ...)``` below with ```device.run(circuit, s3_folder, ...)```, where `s3_folder = (my_bucket, my_prefix)`. If you don't specify the S3 location, default S3 folder, where all inputs and outputs for your tasks are saved, follows the convention `amazon-braket-<region>-<account number>`. "
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {},


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* After making S3 an optional parameter and removing the previous S3 environment configuration cell in https://github.com/aws/amazon-braket-examples/pull/110 a "NOTE" that was no longer needed was lingering. This PR clean-up this along with an unnecessary branching logic in the Grover example.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
