### PR TITLE
fix: added missing dm1 info in documentation

### DIFF
--- a/examples/getting_started/1_Running_quantum_circuits_on_simulators.ipynb
+++ b/examples/getting_started/1_Running_quantum_circuits_on_simulators.ipynb
@@ -13,7 +13,7 @@
    "source": [
     "This hello-world tutorial prepares a paradigmatic example for a multi-qubit entangled state, the so-called [GHZ state](https://en.wikipedia.org/wiki/Greenberger%E2%80%93Horne%E2%80%93Zeilinger_state) (named after the three physicists Greenberger, Horne and Zeilinger). The GHZ state is extremely non-classical, and therefore very sensitive to decoherence. Therefore, it is often used as a performance benchmark for today's hardware. Moreover, in many quantum information protocols it is used as a resource for quantum error correction, quantum communication and quantum metrology. \n",
     "\n",
-    "Amazon Braket offers several classical simulators including a local simulator and two managed simulators: a full state-vector simulator SV1, and a tensor-network simulator TN1. As shown below, one can seamlessly swap between different devices without any modifications to the circuit definition, by just re-defining the device object."
+    "Amazon Braket offers several classical simulators including a local simulator and three managed simulators: a full state-vector simulator SV1, a density matrix simulator DM1, and a tensor-network simulator TN1. You can seamlessly swap between different devices without any modifications to the circuit definition, as shown below, by just re-defining the device object. For additional information about simulators, see the [Amazon Braket Dev Guide](https://docs.aws.amazon.com/braket/latest/developerguide/braket-devices.html#choose-a-simulator)."
    ]
   },
   {
@@ -331,7 +331,16 @@
    "source": [
     "Apart from the local simulator, you can also run your circuit on a managed simulator. This approach adds some latency overhead, but is beneficial for larger circuits by leveraging the optimized cloud hardware infrastructure. Moreover, all your results will be stored reliably in S3. Here, as part of the API call with ```run()``` you need to supply a S3 location where the metadata and results associated with this circuit execution will be stored.\n",
     "\n",
-    "Amazon Braket provides two managed simulators: SV1 and TN1. SV1 calculates and keeps track of the full state vector evolution, supporting simulations of circuits with up to 34 qubits. TN1 is a tensor-network simulator, where each gate in a circuit is represented as a tensor. Compared with SV1, TN1 can simulate a larger number of qubits for circuits with local gates or other special structure, but typically is slower for circuits with long-range or all-to-all gate structure."
+    "Amazon Braket provides three managed simulators:\n",
+    "* SV1\n",
+    "\n",
+    "    State vector simulator  supports simulations of circuits with up to 34 qubits, calculates and keeps track of the full state vector evolution.\n",
+    "* TN1\n",
+    "\n",
+    "    Tensor-network simulator represents each gate in a circuit as a tensor. TN1 can simulate a larger number of qubits for circuits with local gates or other special structure as compared with SV1 and DM1, but typically is slower for circuits with long-range or all-to-all gate structure.\n",
+    "* DM1\n",
+    "\n",
+    "    Density matrix simulator stores the full density matrix of the system and sequentially applies gates and noise operations of the circuit."
    ]
   },
   {


### PR DESCRIPTION
Issue #, if available:
https://app.asana.com/0/1201412419761249/1201895597479544/f
Description of changes:
Added dm1 info that was missing from some documentation. Added link to dev guide to help user choose a simulator.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.