### PR TITLE
Fix broken links in the README Simple Circuits and Algorithms section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,23 +15,23 @@ The repository is structured as follows:
 ---
 ## <a name="simple">Simple circuits and algorithms</a>
 
-  * [**Getting started**](examples/getting_started/0_Getting_started.ipynb)
+  * [**Getting started**](examples/getting_started/0_Getting_started/0_Getting_started.ipynb)
 
     A hello-world tutorial that shows you how to build a simple circuit and run it on a local simulator.
 
-  * [**Running quantum circuits on simulators**](examples/getting_started/1_Running_quantum_circuits_on_simulators.ipynb)
+  * [**Running quantum circuits on simulators**](examples/getting_started/1_Running_quantum_circuits_on_simulators/1_Running_quantum_circuits_on_simulators.ipynb)
 
     This tutorial prepares a paradigmatic example for a multi-qubit entangled state, the so-called GHZ state (named after the three physicists Greenberger, Horne, and Zeilinger). The GHZ state is extremely non-classical, and therefore very sensitive to decoherence. For this reason, it is often used as a performance benchmark for today's hardware. Moreover, in many quantum information protocols it is used as a resource for quantum error correction, quantum communication, and quantum metrology.
 
-  * [**Running quantum circuits on QPU devices**](examples/getting_started/2_Running_quantum_circuits_on_QPU_devices.ipynb)
+  * [**Running quantum circuits on QPU devices**](examples/getting_started/2_Running_quantum_circuits_on_QPU_devices/2_Running_quantum_circuits_on_QPU_devices.ipynb)
 
     This tutorial prepares a maximally-entangled Bell state between two qubits, for classical simulators and for QPUs. For classical devices, we can run the circuit on a local simulator or a cloud-based on-demand simulator. For the quantum devices, we run the circuit on the superconducting machine from Rigetti, and on the ion-trap machine provided by IonQ. As shown, one can swap between different devices seamlessly, without any modifications to the circuit definition, by re-defining the device object. We also show how to recover results using the unique Amazon resource identifier (ARN) associated with every task. This tool is useful if you must deal with potential delays, which can occur if your quantum task sits in the queue awaiting execution.  
 
-  * [**Deep Dive into the anatomy of quantum circuits**](examples/getting_started/3_Deep_dive_into_the_anatomy_of_quantum_circuits.ipynb)
+  * [**Deep Dive into the anatomy of quantum circuits**](examples/getting_started/3_Deep_dive_into_the_anatomy_of_quantum_circuits/3_Deep_dive_into_the_anatomy_of_quantum_circuits.ipynb)
 
     This tutorial discusses in detail the anatomy of quantum circuits in the Amazon Braket SDK. Specifically, you'll learn how to build (parameterized) circuits and display them graphically, and how to append circuits to each other. We discuss the associated circuit depth and circuit size. Finally we show how to execute the circuit on a device of our choice (defining a quantum task). We then learn how to track, log, recover, or cancel such a _quantum task_ efficiently.
 
-  * [**Superdense coding**](examples/getting_started/4_Superdense_coding.ipynb)
+  * [**Superdense coding**](examples/getting_started/4_Superdense_coding/4_Superdense_coding.ipynb)
 
     This tutorial constructs an implementation of the _superdense coding_ protocol, by means of the Amazon Braket SDK. Superdense coding is a method of transmitting two classical bits by sending only one qubit. Starting with a pair of entanged qubits, the sender (_aka_ Alice) applies a certain quantum gate to their qubit and sends the result to the receiver (_aka_ Bob), who is then able to decode the full two-bit message.     
 


### PR DESCRIPTION
*Issue:*
The issue is that links are broken in the README. I did not create an issue as this seems to be a straight-forward fix. 

*Description of changes:*
Changed README links to reflect correct file structure as they are all missing their immediate parent folder. e.g. `examples/getting_started/0_Getting_started.ipynb` becomes `examples/getting_started/0_Getting_started/0_Getting_started.ipynb`

I tested each link to confirm that the functionality was as expected. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. 
