### PR TITLE
Update package versions for the QNSPSA example.

### DIFF
--- a/examples/hybrid_jobs/6_QNSPSA_optimizer_with_embedded_simulator/qnspsa_with_embedded_simulator.ipynb
+++ b/examples/hybrid_jobs/6_QNSPSA_optimizer_with_embedded_simulator/qnspsa_with_embedded_simulator.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "8e093b52",
+   "id": "d59240e2",
    "metadata": {},
    "source": [
     "# Benchmarking QN-SPSA optimizer with Amazon Braket Hybrid Jobs and embedded simulators\n",
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "232d37a1",
+   "id": "de31f8e1",
    "metadata": {},
    "source": [
     "## Introduction on Hybrid Jobs and embedded simulators\n",
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d3e3ad88",
+   "id": "a37aaac1",
    "metadata": {},
    "source": [
     "## Background\n",
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f09cda66",
+   "id": "6a265cfe",
    "metadata": {},
    "source": [
     "### QN-SPSA optimizer\n",
@@ -72,7 +72,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0108a8c4",
+   "id": "edf3ec15",
    "metadata": {},
    "source": [
     "## Notebook dependencies"
@@ -80,7 +80,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "939a6720",
+   "id": "ff864548",
    "metadata": {},
    "source": [
     "<div class=\"alert alert-block alert-info\">\n",
@@ -88,7 +88,6 @@
     "   <ul>\n",
     "    <li>Pennylane version <b>0.22.0</b> (or later)</li>\n",
     "    <li>Braket SDK version <b>1.20.0</b> (or later)</li>\n",
-    "    <li>networkx version <b>2.6.3</b> (or later)</li>\n",
     "</ul>   \n",
     "    \n",
     "</div>"
@@ -97,7 +96,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "1951639a",
+   "id": "84d624bc",
    "metadata": {},
    "outputs": [
     {
@@ -105,8 +104,7 @@
      "output_type": "stream",
      "text": [
       "Current pennylane version 0.22.0\n",
-      "Current braket sdk version 1.20.0\n",
-      "Current networkx version 2.6.3\n"
+      "Current braket sdk version 1.20.0\n"
      ]
     }
    ],
@@ -125,17 +123,15 @@
     "import time\n",
     "import boto3\n",
     "import matplotlib.pyplot as plt\n",
-    "from itertools import chain, combinations\n",
     "\n",
     "# check package versions\n",
     "print(\"Current pennylane version\", qml.__version__)\n",
-    "print(\"Current braket sdk version\", braket_sdk.__version__)\n",
-    "print(\"Current networkx version\", nx.__version__)"
+    "print(\"Current braket sdk version\", braket_sdk.__version__)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "cece6101",
+   "id": "b74b3298",
    "metadata": {},
    "source": [
     "## Implementation and notebook test\n",
@@ -144,7 +140,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cf48204e",
+   "id": "890ad3b5",
    "metadata": {},
    "source": [
     "We have included the optimizer class in `source_scripts/QNSPSA.py`. It follows PennyLane's convention for [optimizers](https://pennylane.readthedocs.io/en/stable/introduction/optimizers.html), with two class methods exposed to the users:\n",
@@ -155,7 +151,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ae39e9f1",
+   "id": "263f3fc4",
    "metadata": {},
    "source": [
     "The optimizer's core process can be found in the `__step_core()` function. The functions `__get_spsa_grad_tapes()` and `__get_tensor_tapes()` schedule the circuits to be executed for the stochastic gradient estimation and tensor metric estimation, and `qml.execute()` sends them to the simulator device."
@@ -164,7 +160,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "161e996c",
+   "id": "f5451383",
    "metadata": {},
    "outputs": [
     {
@@ -189,12 +185,12 @@
     }
    ],
    "source": [
-    "!sed -n 106,119p source_scripts/QNSPSA.py"
+    "!sed -n 110,123p source_scripts/QNSPSA.py"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "352e6925",
+   "id": "2c49da60",
    "metadata": {},
    "source": [
     "To confirm the optimizer works correctly, let's work with a toy QAOA maximum cut example [6]. The maximum cut problem is to partition the nodes of a graph into two subsets such that the number of edges going between the subsets is maximized. The QAOA max cut problem can be conveniently set up with the [PennyLane's QAOA module](https://pennylane.readthedocs.io/en/stable/code/api/pennylane.qaoa.cost.maxcut.html). You can find a more detailed and visualized example [here](https://github.com/aws/amazon-braket-examples/blob/17ba255396f4c2bf773dde99a5c46486e822776e/examples/hybrid_jobs/2_Using_PennyLane_with_Braket_Jobs/Using_PennyLane_with_Braket_Jobs.ipynb)."
@@ -203,7 +199,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "d92fa8d1",
+   "id": "8e2878ed",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -241,7 +237,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "269f1384",
+   "id": "87c43d02",
    "metadata": {},
    "source": [
     "In QAOA, the loss is given by the expectation value of the cost Hamiltonian. The negation of the loss represents the number of edges between the two subsets, while the two subsets are specified by the $Z$ values of each qubit (node). Nodes with the same $Z$ value are of the same subset. Finding the maximum cut is then equivalent to finding the mininum-energy state of the cost Hamiltonian, which is done variationally in the QAOA algorithm. The basic building block of the QAOA ansatz is a cost layer followed with a mixer layer. This building block repeats for $p$ times resulting in the final ansatz circuit. A larger $p$ value leads generally to better approximations of the solution in the ideal case, however, the noise on real QPUs will prevent you from going to higher values since the circuits get deeper with increasing $p$. In practice, a lot of experimentation is required to find the best values for your problem and device choice."
@@ -249,7 +245,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b0fde6a4",
+   "id": "5261eb95",
    "metadata": {},
    "source": [
     "Now let's take a look if our optimizer indeed reduces the loss."
@@ -258,23 +254,23 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "87e4d3bd",
+   "id": "0215a780",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Step 0: cost = -1.2218\n",
-      "Step 10: cost = -2.5597\n",
-      "Step 20: cost = -2.7156\n",
-      "Step 30: cost = -2.7259\n",
-      "Step 40: cost = -2.7413\n",
-      "Step 50: cost = -2.7498\n",
-      "Step 60: cost = -2.7557\n",
-      "Step 70: cost = -2.7568\n",
-      "Step 80: cost = -2.7641\n",
-      "Step 90: cost = -2.7743\n"
+      "Step 0: cost = -1.6159\n",
+      "Step 10: cost = -2.0127\n",
+      "Step 20: cost = -2.0191\n",
+      "Step 30: cost = -2.4048\n",
+      "Step 40: cost = -2.7166\n",
+      "Step 50: cost = -2.7435\n",
+      "Step 60: cost = -2.7589\n",
+      "Step 70: cost = -2.7612\n",
+      "Step 80: cost = -2.7770\n",
+      "Step 90: cost = -2.7909\n"
      ]
     }
    ],
@@ -293,7 +289,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8ea0c119",
+   "id": "fee4eca3",
    "metadata": {},
    "source": [
     "As the loss drops and finally converges, we can tell that the optimizer works! "
@@ -301,7 +297,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bce016ef",
+   "id": "9d726925",
    "metadata": {},
    "source": [
     "## Comparing QN-SPSA with other optimizers\n",
@@ -318,7 +314,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "96f1429b",
+   "id": "ef52d605",
    "metadata": {},
    "source": [
     "We have prepared an an algorithm script,  `source_scripts/benchmark_ref_paper_converge_speed`, which reproduces the experiment in Fig 1(b) from Ref. [1] with the selected optimizer from the four candidates (GD, QNG, QNSPSA, SPSA). First, let's test if the script works as expected. Hybrid Jobs provides a [local mode](https://docs.aws.amazon.com/braket/latest/developerguide/braket-jobs-local-mode.html) for testing and debugging. It enables you to quickly test your code in your local environment, e.g. a Braket notebook, before running it remotely on a job instance. Let's start by selecting the Braket base container which comes pre-installed with PennyLane. "
@@ -327,7 +323,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "be53b370",
+   "id": "4eb770e1",
    "metadata": {},
    "outputs": [
     {
@@ -347,7 +343,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "167a5313",
+   "id": "3e18d6cb",
    "metadata": {},
    "source": [
     "We can then start a local job using the code below. We first set the hyperparameters, give our job a name, and then create it using the `LocalQuantumJob` API. Since QN-SPSA is a stochastic method, we repeat the algorithm `spsa_repeats` times to capture the average performance."
@@ -356,7 +352,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "03080905",
+   "id": "cc39ab60",
    "metadata": {},
    "outputs": [
     {
@@ -424,7 +420,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "234f74d3",
+   "id": "66d52ba5",
    "metadata": {},
    "source": [
     "Note that each local Job will create a folder under the current path storing the log and result so you can understand the details of the test if needed."
@@ -432,7 +428,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2f0e130b",
+   "id": "4f590b32",
    "metadata": {},
    "source": [
     "Now that we have confirmed the code works correctly, we can reproduce the full benchmark of Ref [1]. In the following cell, we will create a set of jobs, one for each optimizer. The four jobs will start and execute in parallel, allowing us to speed up the experiment. For now, we will use a relatively small instance type, `ml.m5.large`, which has 2 vCPUs and 8 GiB of memory."
@@ -441,7 +437,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "75464ba3",
+   "id": "c33f9f78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -465,7 +461,7 @@
     "max_iter = hyperparameters[\"max_iter\"]\n",
     "\n",
     "jobs = []\n",
-    "for i in range(4):\n",
+    "for i in range(len(optimizers)):\n",
     "    hyperparameters[\"spsa_repeats\"] = repeats[i]\n",
     "    hyperparameters[\"optimizer\"] = optimizers[i]\n",
     "    job_name = f\"ref-paper-benchmark-qubit{n_qubits}-opt{optimizers[i]}\" + str(int(time.time()))\n",
@@ -487,7 +483,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3cbeb586",
+   "id": "53dc064e",
    "metadata": {},
    "source": [
     "After you create your job it will asynchronously run on Braket and not block your notebook. You can continue to work in your notebook while the job is executing and check back on the results after the job has completed.\n",
@@ -498,7 +494,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "0997fed4",
+   "id": "4525156b",
    "metadata": {},
    "outputs": [
     {
@@ -516,7 +512,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cdbead7f",
+   "id": "7ede96f8",
    "metadata": {},
    "source": [
     "It takes about 50 min for the longest of the four jobs to finish. As of writing of this example the cost of an `ml.m5.large` instance is $\\$0.115$ per hour, so that the estimated cost of running this cell is well below $\\$1$.\n",
@@ -527,7 +523,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "d93575e7",
+   "id": "a841643c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -536,7 +532,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24942b39",
+   "id": "0d254dcb",
    "metadata": {},
    "source": [
     "We can now process the result and visualize the performance of each optimizer."
@@ -545,7 +541,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "a9de3bf6",
+   "id": "fa7788d4",
    "metadata": {},
    "outputs": [
     {
@@ -597,7 +593,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8b6acc87",
+   "id": "5c0a4940",
    "metadata": {},
    "source": [
     "The above plot shows how the loss drops over optimization steps. The purple/green solid line represents the average of the 25 curves for SPSA/QN-SPSA. The purple/green shaded area stands for the envelope of all 25 curves for SPSA/QN-SPSA. \n",
@@ -610,7 +606,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "id": "751d1ddb",
+   "id": "9fab21fc",
    "metadata": {},
    "outputs": [
     {
@@ -633,7 +629,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f7f2d122",
+   "id": "14cac693",
    "metadata": {},
    "source": [
     "## Benchmarking with QAOA\n",
@@ -645,7 +641,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "id": "cfaeda4d",
+   "id": "8afff2b6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -662,7 +658,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2bddecbb",
+   "id": "9ca17b0c",
    "metadata": {},
    "source": [
     "As before, we provide you with the code to run this benchmark in the script `source_scripts/benchmark_qaoa_converge_speed`, so you can readily reproduce the results using Hybrid Jobs. The problem graph is defined with a node number of `n_qubits`, an edge number of `edges`, and a `seed` value. We have selected a fixed learning rate for each optimizer based on experience. In a real world experiment, you would fine tune each method during hyperparameter optimization, which goes beyond the scope of this example.  The following two cells take about 60 min to finish."
@@ -671,7 +667,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "id": "8d034eab",
+   "id": "ce8a4c11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -697,7 +693,7 @@
     "max_iter = hyperparameters[\"max_iter\"]\n",
     "\n",
     "jobs = []\n",
-    "for i in range(4):\n",
+    "for i in range(len(optimizers)):\n",
     "    hyperparameters[\"spsa_repeats\"] = repeats[i]\n",
     "    hyperparameters[\"optimizer\"] = optimizers[i]\n",
     "    hyperparameters[\"learn_rate\"] = learn_rates[i]\n",
@@ -722,7 +718,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "id": "57fd9fd5",
+   "id": "9c794f8c",
    "metadata": {},
    "outputs": [
     {
@@ -772,7 +768,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a69a04c3",
+   "id": "75f18378",
    "metadata": {},
    "source": [
     "GD, QNG and QN-SPSA are able to minimize the loss function to be below -13, giving an estimated ground state of -14 for the max cut problem compared to the true ground state energy of -16. As before, GD and QNG seem to outperform QN-SPSA when considering step-wise convergence. However, each step in GD and QNG require significantly more circuit executions compared to the stochastic QN-SPSA. Let's have a closer look at that."
@@ -780,7 +776,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f0cd1b9e",
+   "id": "ddfa093d",
    "metadata": {},
    "source": [
     "When we look at the time per step in our simulations, we can clearly see signals that GD and QNG are more expensive on a per-step basis."
@@ -789,7 +785,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "id": "31b0ec47",
+   "id": "c96d9acd",
    "metadata": {},
    "outputs": [
     {
@@ -812,7 +808,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a8312492",
+   "id": "28cb4b50",
    "metadata": {},
    "source": [
     "The reason of the long optimization time per step for GD and QNG to optimize per step is in the gradient computation. The analytical optimizers (QNG, GD) compute gradients via the parameter shift rule, which requires executing 2$n_G$ circuits, where $n_G$ is the parameterized gate number. QAOA ansatz has only $2p$ parameters, but a rather large amount of parameterized gates. On the other hand, stochastic methods (QN-SPSA, SPSA) always execute a fixed number of circuits for each step, independent of the problem size. "
@@ -820,7 +816,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2cd430f1",
+   "id": "d7a3e00f",
    "metadata": {},
    "source": [
     "## Scaling up: QN-SPSA on larger problems"
@@ -828,7 +824,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c28fd800",
+   "id": "ecda1645",
    "metadata": {},
    "source": [
     "The behavior and performance of different optimizers depend strongly on the problem instance and, in particular, the problem size.  As we have seen above, analytical gradient estimation, such as employed in GD and QNG quickly become impractical when the system size gets larger, due to the increasing number tasks and shots that are required to calculate the gradient. Stochastic optimizers, such as QN-SPSA are designed to overcome this challenge. Let's take a look how QN-SPSA performs as we go to larger system sizes. In the following cells, we simulate a larger QAOA graph with 29 nodes and 58 edges. We use PennyLane's GPU simulator `lightning.gpu` for this workload, as it provides up to 10X speedup for intermediate scale problems (problems with 20-29 qubits). Before you run the cell, note that QN-SPSA takes 3.5 min per step, and about 3.5 hours overall to finish the algorithm."
@@ -837,7 +833,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "id": "91cc9b6e",
+   "id": "fa4c091f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -880,7 +876,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d6df1d99",
+   "id": "4b862ff1",
    "metadata": {},
    "source": [
     "Let's take a look at the results:"
@@ -889,7 +885,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "id": "b77aeaa9",
+   "id": "66c42dda",
    "metadata": {},
    "outputs": [
     {
@@ -920,7 +916,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e8b70ef0",
+   "id": "e3e08522",
    "metadata": {},
    "source": [
     "The QAOA algorithm provides a minimized loss value of -40. To further improve the QAOA solution from here, you can try to increase $p$ from 2 to a larger integer, or experiment with the other hyperparameters. As the simulator's execution time scales roughly linearly with $p$, you should expect a longer run time."
@@ -928,7 +924,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f00d776a",
+   "id": "9060482b",
    "metadata": {},
    "source": [
     "## Embedded simulator vs on-demand simulator\n",
@@ -938,7 +934,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8d8b6ec5",
+   "id": "844c23ff",
    "metadata": {},
    "source": [
     "On the other hand, On-demand simulators have the [task batching](https://docs.aws.amazon.com/braket/latest/developerguide/braket-batching-tasks.html?tag=local002) feature to run circuit simulation tasks in parallel, which is integrated into PennyLane's `qml.execute()` function. When the quantum algorithm can be efficiently parallelized, we would expect the on-demand simulators to provide a reasonable speedup. "
@@ -946,7 +942,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7b537a7a",
+   "id": "af1be06d",
    "metadata": {},
    "source": [
     "Note that this speedup from task parallelization is algorithm specific. For QN-SPSA, we have written the optimizer class in a way it can best utilize the task batching. With the SV1 on-demand simulator, the same 29-node-graph QAOA problem has a step-wise optimization time of 3.5 min, similar to the result from the embedded simulator `lightning.gpu`."
@@ -954,7 +950,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bc241581",
+   "id": "49890900",
    "metadata": {},
    "source": [
     "# Conclusion\n",
@@ -964,7 +960,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7ffeeb3d",
+   "id": "9dc54d2e",
    "metadata": {},
    "source": [
     "# References\n",
@@ -999,7 +995,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.7.13"
   },
   "vscode": {
    "interpreter": {

--- a/examples/hybrid_jobs/6_QNSPSA_optimizer_with_embedded_simulator/source_scripts/qaoa_large_problem.py
+++ b/examples/hybrid_jobs/6_QNSPSA_optimizer_with_embedded_simulator/source_scripts/qaoa_large_problem.py
@@ -1,7 +1,7 @@
 import subprocess
 
 subprocess.run(["pip", "install", "pennylane==0.24.0", "-q"])
-subprocess.run(["pip", "install", "pennylane-lightning-gpu==0.24.0", "-q"])
+subprocess.run(["pip", "install", "pennylane-lightning-gpu~=0.24", "-q"])
 import os
 import pennylane as qml
 from pennylane import numpy as np


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:* 
- Remove the statement that the notebook requires `networkx==2.6.3`, as this dependency has been previously removed. 
- Update the upgrading command for `lightning.gpu` in the job script, reflecting the bug fix from PennyLane on June 30. (https://github.com/PennyLaneAI/pennylane-lightning-gpu/pull/36). Now the job script installs `lightning.gpu` v0.24.1
- Small readability improvements

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
