### PR TITLE
change: exclude QML notebook from tests

### DIFF
--- a/test/notebook_tests/test_notebooks.py
+++ b/test/notebook_tests/test_notebooks.py
@@ -29,7 +29,8 @@ test_notebooks = []
 EXCLUDED_NOTEBOOKS = [
     "4_Operating_Borealis_beginner_tutorial.ipynb",
     "bring_your_own_container.ipynb",
-    "qnspsa_with_embedded_simulator.ipynb"
+    "qnspsa_with_embedded_simulator.ipynb",
+    "Parallelize_training_for_QML.ipynb"
 ]
 
 

--- a/test/notebook_tests/test_notebooks.py
+++ b/test/notebook_tests/test_notebooks.py
@@ -30,7 +30,7 @@ EXCLUDED_NOTEBOOKS = [
     "4_Operating_Borealis_beginner_tutorial.ipynb",
     "bring_your_own_container.ipynb",
     "qnspsa_with_embedded_simulator.ipynb",
-    "Parallelize_training_for_QML.ipynb"
+    "Parallelize_training_for_QML.ipynb",
 ]
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Excluding QML notebook from tests since those run with `instanceType='ml.p3.16xlarge'` for lightning.gpu and are not conflicts with tests schedule with jobs being stuck in QUEUED state. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
