### PR TITLE
change: exclude embedded sim notebook from tests

### DIFF
--- a/test/notebook_tests/test_notebooks.py
+++ b/test/notebook_tests/test_notebooks.py
@@ -31,6 +31,7 @@ EXCLUDED_NOTEBOOKS = [
     "bring_your_own_container.ipynb",
     "qnspsa_with_embedded_simulator.ipynb",
     "Parallelize_training_for_QML.ipynb",
+    "Embedded_simulators_in_Braket_Jobs.ipynb",
 ]
 
 


### PR DESCRIPTION
Temporarily excluding embedded sim notebook from tests since some instances getting stuck for jobs until sagemaker limits are increased.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
