### PR TITLE
change: re-enable tests for embedded_sim & qml notebooks

### DIFF
--- a/test/notebook_tests/test_notebooks.py
+++ b/test/notebook_tests/test_notebooks.py
@@ -30,8 +30,6 @@ EXCLUDED_NOTEBOOKS = [
     "4_Operating_Borealis_beginner_tutorial.ipynb",
     "bring_your_own_container.ipynb",
     "qnspsa_with_embedded_simulator.ipynb",
-    "Parallelize_training_for_QML.ipynb",
-    "Embedded_simulators_in_Braket_Jobs.ipynb",
 ]
 
 


### PR DESCRIPTION
Adding  "Parallelize_training_for_QML.ipynb" and "Embedded_simulators_in_Braket_Jobs.ipynb" back for tests.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
