### PR TITLE
fix: run verbatim circuit on OQC device

### DIFF
--- a/examples/braket_features/Verbatim_Compilation.ipynb
+++ b/examples/braket_features/Verbatim_Compilation.ipynb
@@ -786,7 +786,7 @@
     }
    ],
    "source": [
-    "result = oqc_device.run(verbatim_circ, shots=1000, disable_qubit_rewiring=True).result()\n",
+    "result = oqc_device.run(verbatim_circ, shots=1000).result()\n",
     "compiledProgram = result.additional_metadata.oqcMetadata.compiledProgram\n",
     "print(compiledProgram)\n",
     "print(result.measurement_counts)"


### PR DESCRIPTION
*Description of changes:*
OQC's Lucy device does not support `disable_qubit_rewiring=True` any more. Remove it from cell 22 in the "Verbatim Compilation" notebook which is causing validation error currently.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
