### PR TITLE
Fix links to OpenQASM documentation

### DIFF
--- a/examples/braket_features/Getting_Started_with_OpenQASM_on_Braket.ipynb
+++ b/examples/braket_features/Getting_Started_with_OpenQASM_on_Braket.ipynb
@@ -504,7 +504,7 @@
    "source": [
     "## Qubit Rewiring with OpenQASM\n",
     "\n",
-    "Amazon Braket supports the [physical qubit notation within OpenQASM](https://qiskit.github.io/openqasm/language/types.html#physical-qubits) on Rigetti devices. When using physical qubits, you have to ensure that the qubits are indeed connected on the selected device. Alternatively, if qubit registers are used instead, the `PARTIAL` rewiring strategy is enabled by default on Rigetti devices. The following example shows how to use physical qubit notation in an OpenQASM program:"
+    "Amazon Braket supports the [physical qubit notation within OpenQASM](https://openqasm.com/language/types.html#physical-qubits) on Rigetti devices. When using physical qubits, you have to ensure that the qubits are indeed connected on the selected device. Alternatively, if qubit registers are used instead, the `PARTIAL` rewiring strategy is enabled by default on Rigetti devices. The following example shows how to use physical qubit notation in an OpenQASM program:"
    ]
   },
   {
@@ -855,7 +855,7 @@
    "source": [
     "# Conclusion\n",
     "\n",
-    "In this notebook, you learned how to submit OpenQASM tasks and use OpenQASM features on Braket. Hope you enjoyed it! You can find more information about OpenQASM3.0 in its [live specification](https://qiskit.github.io/openqasm/index.html), and you can learn more about OpenQASM support on Braket in the [Amazon Braket documentation](https://docs.aws.amazon.com/braket/latest/developerguide/)."
+    "In this notebook, you learned how to submit OpenQASM tasks and use OpenQASM features on Braket. Hope you enjoyed it! You can find more information about OpenQASM3.0 in its [live specification](https://openqasm.com/), and you can learn more about OpenQASM support on Braket in the [Amazon Braket documentation](https://docs.aws.amazon.com/braket/latest/developerguide/)."
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Two links to OpenQASM documentation in the `Getting_Started_with_OpenQASM_on_Braket.ipynb` notebook are broken. The documentation has been moved from the old location https://qiskit.github.io/openqasm/ to the new location at https://openqasm.com/. This change just fixes those links.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
