### PR TITLE
fix: Exclude Aquila notebooks from tests

### DIFF
--- a/test/notebook_tests/test_notebooks.py
+++ b/test/notebook_tests/test_notebooks.py
@@ -32,6 +32,10 @@ EXCLUDED_NOTEBOOKS = [
     "qnspsa_with_embedded_simulator.ipynb",
     "Parallelize_training_for_QML.ipynb",
     "Embedded_simulators_in_Braket_Jobs.ipynb",
+    # Temporarily exclude Aquila notebooks
+    "01_Introduction_to_Aquila.ipynb",
+    "02_Ordered_phases_in_Rydberg_systems.ipynb",
+    "03_Parallel_tasks_on_Aquila.ipynb"
 ]
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
