### PR TITLE
fix: number of electrons in gradient computation

### DIFF
--- a/examples/pennylane/6_Adjoint_gradient_computation/6_Adjoint_gradient_computation.ipynb
+++ b/examples/pennylane/6_Adjoint_gradient_computation/6_Adjoint_gradient_computation.ipynb
@@ -78,7 +78,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Again, we will represent the molecule we want to simulate using the `xyz` format. An `xyz` file with the structure of $\\mathrm{CO}_2$ is provided in this folder as `co2.xyz`. We'll also set the number of active electrons to simulate. Active electrons are those which can transition between energy levels through an excitation: single, double, or more. Including more active electrons will increase the number of qubits we need to simulate this molecule. In this tutorial, we will set the number of active electrons to `8` - less than the 22 total electrons present in $\\mathrm{CO}_2$. In practice, it's usually possible to get accurate results using far fewer active electrons than total electrons in the molecule, as most electrons do not participate in bonding.\n",
+    "Again, we will represent the molecule we want to simulate using the `xyz` format. An `xyz` file with the structure of $\\mathrm{CO}_2$ is provided in this folder as `co2.xyz`. We'll also set the number of active electrons to simulate. Active electrons are those which can transition between energy levels through an excitation: single, double, or more. Including more active electrons will increase the number of qubits we need to simulate this molecule. In this tutorial, we will set the number of active electrons to `2` - less than the 22 total electrons present in $\\mathrm{CO}_2$. In practice, it's usually possible to get accurate results using far fewer active electrons than total electrons in the molecule, as most electrons do not participate in bonding.\n",
     "\n",
     "We'll use the `pyscf` method to build the Hamiltonian, which uses the OpenFermion-PySCF plugin to build a *non-differentiable* molecular Hamiltonian. Since we are interested in optimizing the *excitations*, and not the Hamiltonian itself, this is a reasonable choice that will lower the total number of derivatives we will need to compute, because the Hamiltonian itself will not be parametrized. For more information about this plugin, see [the PennyLane documentation](https://docs.pennylane.ai/en/stable/code/qml_qchem.html?highlight=pyscf#openfermion-pyscf-backend)."
    ]
@@ -92,12 +92,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Number of qubits: 16\n"
+      "Number of qubits: 10\n"
      ]
     }
    ],
    "source": [
-    "n_electrons = 8\n",
+    "n_electrons = 2\n",
     "symbols, coordinates = qchem.read_structure('qchem/co2.xyz')\n",
     "# suppress a HDF5 warning\n",
     "import warnings\n",
@@ -127,8 +127,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Number of single excitations:  32\n",
-      "Number of double excitations:  328\n"
+      "Number of single excitations:  8\n",
+      "Number of double excitations:  16\n"
      ]
     }
    ],
@@ -238,7 +238,7 @@
    "metadata": {},
    "source": [
     "<div class=\"alert alert-block alert-warning\">\n",
-    "<b>Caution</b> This cell may take about 30s to run on SV1.\n",
+    "<b>Caution</b> This cell may take about 15 seconds to run on SV1.\n",
     "</div>"
    ]
   },
@@ -253,7 +253,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Time to compute all double excitation derivatives with adjoint differentiation: 35.137124973\n"
+      "Time to compute all double excitation derivatives with adjoint differentiation: 11.82757306098938\n"
      ]
     }
    ],
@@ -294,8 +294,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Total number of doubles 328\n",
-      "Total number of selected doubles 84\n"
+      "Total number of doubles 16\n",
+      "Total number of selected doubles 6\n"
      ]
     }
    ],
@@ -429,7 +429,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Time to compute all singles derivatives with adjoint differentiation: 24.99084433400003\n"
+      "Time to compute all singles derivatives with adjoint differentiation: 10.566177368164062\n"
      ]
     }
    ],
@@ -469,8 +469,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Total number of singles 32\n",
-      "Total number of selected singles 4\n"
+      "Total number of singles 8\n",
+      "Total number of selected singles 0\n"
      ]
     }
    ],
@@ -575,7 +575,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Best energy: -184.90690906527988\n"
+      "Best energy: -184.84566047212155\n"
      ]
     }
    ],
@@ -673,7 +673,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Time to compute 35 double excitation derivatives using unbatched parameter shift: 3091.6812979720003\n"
+      "Time to compute 16 double excitation derivatives using unbatched parameter shift: 382.5654754638672\n"
      ]
     }
    ],
@@ -746,7 +746,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Time to compute 35 double excitation derivatives using batched parameter shift: 1497.8131681899995\n"
+      "Time to compute 16 double excitation derivatives using batched parameter shift: 71.81587219238281\n"
      ]
     }
    ],
@@ -771,7 +771,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Extrapolated time to compute all doubles derivatives with unbatched parameter shift: 28973.470449566175\n"
+      "Extrapolated time to compute all doubles derivatives with unbatched parameter shift: 382.5654754638672\n"
      ]
     }
    ],
@@ -782,14 +782,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Extrapolated time to compute all doubles derivatives with batched parameter shift: 14036.649119037711\n"
+      "Extrapolated time to compute all doubles derivatives with batched parameter shift: 71.81587219238281\n"
      ]
     }
    ],
@@ -807,7 +807,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -815,7 +815,7 @@
      "output_type": "stream",
      "text": [
       "Time to compute all doubles derivatives:\n",
-      "Ratio of (extrapolated) unbatched parameter shift time to adjoint time: 824.5828442659982\n"
+      "Ratio of (extrapolated) unbatched parameter shift time to adjoint time: 32.34522192263385\n"
      ]
     }
    ],
@@ -834,7 +834,7 @@
      "output_type": "stream",
      "text": [
       "Time to compute all doubles derivatives:\n",
-      "Ratio of (extrapolated) batched parameter shift time to adjoint time: 399.48200456991646\n"
+      "Ratio of (extrapolated) batched parameter shift time to adjoint time: 6.071902648333791\n"
      ]
     }
    ],
@@ -873,8 +873,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[-0.04479306788256261, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -0.044793067882562765, 0.0, 0.0, 0.0, 0.0, -0.035481008824050954, 0.0, 0.0, -0.02328807312335082, 0.0, 0.0, 0.0, 0.0, 0.0, 0.012217382659452488, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]\n",
-      "[-0.04479306788255677, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -0.04479306788255677, 0.0, 0.0, 0.0, 0.0, -0.035481008824046256, 0.0, 0.0, -0.02328807312335357, 0.0, 0.0, 0.0, 0.0, 0.0, 0.012217382659450493, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]\n"
+      "[-0.1443323142339966, -0.03866017183542401, 0.0, 0.0, 0.03866017183542413, 0.0, 0.0, -0.02351511046890015, 0.0, 0.0, 0.0, 0.0, -0.01965603958994852, 0.0, 0.0, -0.022656867519767896]\n",
+      "[-0.14433231423401993, -0.03866017183542633, 2.067087675367537e-15, -6.38299443663491e-15, 0.038660171835431564, 5.3150267037553665e-15, -1.0539239184341589e-15, -0.02351511046890445, 6.950157466088935e-15, 3.524371221874568e-15, 1.6210869478881837e-15, -3.331171073386041e-16, -0.01965603958990775, 2.954516133535175e-15, -5.9272680634660774e-15, -0.022656867519801775]\n"
      ]
     }
    ],
@@ -895,7 +895,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[-0.04479306788255677, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -0.04479306788255677, 0.0, 0.0, 0.0, 0.0, -0.035481008824046256, 0.0, 0.0, -0.02328807312335357, 0.0, 0.0, 0.0, 0.0, 0.0, 0.012217382659450493, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]\n"
+      "[-0.14433231423401993, -0.03866017183542633, 2.067087675367537e-15, -6.38299443663491e-15, 0.038660171835431564, 5.3150267037553665e-15, -1.0539239184341589e-15, -0.02351511046890445, 6.950157466088935e-15, 3.524371221874568e-15, 1.6210869478881837e-15, -3.331171073386041e-16, -0.01965603958990775, 2.954516133535175e-15, -5.9272680634660774e-15, -0.022656867519801775]\n"
      ]
     }
    ],
@@ -924,9 +924,9 @@
      "output_type": "stream",
      "text": [
       "Task Summary\n",
-      "{'arn:aws:braket:::device/quantum-simulator/amazon/sv1': {'shots': 0, 'tasks': {'COMPLETED': 304}, 'execution_duration': datetime.timedelta(seconds=498, microseconds=94000), 'billed_execution_duration': datetime.timedelta(seconds=982, microseconds=876000)}}\n",
+      "{'arn:aws:braket:::device/quantum-simulator/amazon/sv1': {'shots': 0, 'tasks': {'COMPLETED': 152}, 'execution_duration': datetime.timedelta(seconds=27, microseconds=319000), 'billed_execution_duration': datetime.timedelta(seconds=456)}}\n",
       "Note: Charges shown are estimates based on your Amazon Braket simulator and quantum processing unit (QPU) task usage. Estimated charges shown may differ from your actual charges. Estimated charges do not factor in any discounts or credits, and you may experience additional charges based on your use of other services such as Amazon Elastic Compute Cloud (Amazon EC2).\n",
-      "Estimated cost to run this example: 1.229 USD\n"
+      "Estimated cost to run this example: 0.570 USD\n"
      ]
     }
    ],
@@ -940,9 +940,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "conda_braket",
    "language": "python",
-   "name": "python3"
+   "name": "conda_braket"
   },
   "language_info": {
    "codemirror_mode": {
@@ -954,7 +954,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.15"
+   "version": "3.7.15"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Changed electrons from 8 to 2 
- re-ran the notebook 
- change the text where electrons were said to be used as 8. 
- Changed time required from 30 seconds to 15 seconds. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
