### PR TITLE
Fix formula

### DIFF
--- a/examples/advanced_circuits_algorithms/Quantum_Fourier_Transform/Quantum_Fourier_Transform.ipynb
+++ b/examples/advanced_circuits_algorithms/Quantum_Fourier_Transform/Quantum_Fourier_Transform.ipynb
@@ -63,7 +63,7 @@
     "$$\n",
     "\\begin{split}\n",
     "\\mathrm{QFT}\\left|0,0,0\\right> & = \\frac{1}{\\sqrt{2^{3}}}(\\left|0\\right>+\\left|1\\right>) \\otimes (\\left|0\\right>+\\left|1\\right>) \\otimes (\\left|0\\right>+\\left|1\\right>) \\\\\n",
-    " & = \\frac{1}{\\sqrt{2^{3}}} \\bigotimes_{i} \\left|+\\right>_{i}\n",
+    " & = \\bigotimes_{i} \\left|+\\right>_{i}\n",
     "\\end{split}\n",
     "$$\n",
     "\n",


### PR DESCRIPTION
The 1/sqrt(2) s should be absorbed into the |+> states to preserve normalization.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
