### PR TITLE
ahs manually specify steps

### DIFF
--- a/examples/analog_hamiltonian_simulation/00_Introduction_of_Analog_Hamiltonian_Simulation_with_Rydberg_Atoms.ipynb
+++ b/examples/analog_hamiltonian_simulation/00_Introduction_of_Analog_Hamiltonian_Simulation_with_Rydberg_Atoms.ipynb
@@ -446,7 +446,7 @@
    "id": "da67bcf1",
    "metadata": {},
    "source": [
-    "We can run the AHS program just like running a quantum circuit on other Braket devices"
+    "We can run the AHS program just like running a quantum circuit on other Braket devices. Below we have explicitly specified the values of `steps` and `shots`, which are the number of time steps in the simulation and the number of sampling for the final stats, respectively. One could increase the accuracy of the result by increasing the values of these arguments, at the expense of longer runtime. "
    ]
   },
   {
@@ -456,7 +456,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = device.run(ahs_program, shots=1000).result()"
+    "result = device.run(ahs_program, shots=1000, steps=100).result()"
    ]
   },
   {

--- a/examples/analog_hamiltonian_simulation/02_Ordered_phases_in_Rydberg_systems.ipynb
+++ b/examples/analog_hamiltonian_simulation/02_Ordered_phases_in_Rydberg_systems.ipynb
@@ -80,7 +80,7 @@
    "source": [
     "## 1D $Z_2$ phase \n",
     "\n",
-    "Here we consider a 1D chain of 9 atoms with neighboring atoms separated by $5.5\\mu m$. The setup of the system can be generated as follows"
+    "Here we consider a 1D chain of 9 atoms with neighboring atoms separated by $6.1\\mu m$. The setup of the system can be generated as follows"
    ]
   },
   {
@@ -200,7 +200,7 @@
    "id": "37e89b67",
    "metadata": {},
    "source": [
-    "Before running the program on Quera's Aquila device (See notebook 01), we can first run it on the local simulator to make sure the outcome is the expected $Z_2$ state. "
+    "Before running the program on Quera's Aquila device (See notebook 01), we can first run it on the local simulator to make sure the outcome is the expected $Z_2$ state. Below we have explicitly specified the values of `steps` and `shots`, which are the number of time steps in the simulation and the number of sampling for the final stats, respectively. One could increase the accuracy of the result by increasing the values of these arguments, at the expense of longer runtime. "
    ]
   },
   {
@@ -224,7 +224,7 @@
    ],
    "source": [
     "device = LocalSimulator(\"braket_ahs\")\n",
-    "result = device.run(ahs_program, shots=1000).result()\n",
+    "result = device.run(ahs_program, shots=1000, steps=100).result()\n",
     "show_final_avg_density(result)"
    ]
   },

--- a/examples/analog_hamiltonian_simulation/03_Parallel_tasks_on_Aquila.ipynb
+++ b/examples/analog_hamiltonian_simulation/03_Parallel_tasks_on_Aquila.ipynb
@@ -491,7 +491,8 @@
     "plot_avg_density_2D(sim_density, register, custom_axes = ax2);\n",
     "ax2.set_title(\"Simulator Result\");\n",
     "\n",
-    "plt.show()"   ]
+    "plt.show()"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -531,7 +532,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.2"
+   "version": "3.9.7"
   },
   "varInspector": {
    "cols": {

--- a/examples/analog_hamiltonian_simulation/03_Parallel_tasks_on_Aquila.ipynb
+++ b/examples/analog_hamiltonian_simulation/03_Parallel_tasks_on_Aquila.ipynb
@@ -358,7 +358,7 @@
    "id": "69aad79a-a494-463f-911f-2e7fc71d0ff7",
    "metadata": {},
    "source": [
-    "First, we run a non-parallelized register on the local simulator, and sample 400 shots."
+    "First, we run a non-parallelized register on the local simulator, and sample 400 shots. Below we also explicitly specified the values of `steps`, which are the number of time steps in the simulation."
    ]
   },
   {
@@ -371,7 +371,7 @@
     "from braket.devices import LocalSimulator\n",
     "sim = LocalSimulator(\"braket_ahs\")\n",
     "\n",
-    "sim_result = sim.run(ahs_program, shots=400).result()"
+    "sim_result = sim.run(ahs_program, shots=400, steps=100).result()"
    ]
   },
   {

--- a/examples/analog_hamiltonian_simulation/04_Maximum_Independent_Sets_with_Analog_Hamiltonian_Simulation.ipynb
+++ b/examples/analog_hamiltonian_simulation/04_Maximum_Independent_Sets_with_Analog_Hamiltonian_Simulation.ipynb
@@ -280,7 +280,7 @@
     "    #program = program.discretize(device)\n",
     "    \n",
     "    # run the AHS program and extract measurements\n",
-    "    results = device.run(program, shots=1000).result()\n",
+    "    results = device.run(program, shots=1000, steps=100).result()\n",
     "    \n",
     "    \n",
     "    r_counts = []\n",

--- a/examples/analog_hamiltonian_simulation/05_Running_Analog_Hamiltonian_Simulation_with_local_simulator.ipynb
+++ b/examples/analog_hamiltonian_simulation/05_Running_Analog_Hamiltonian_Simulation_with_local_simulator.ipynb
@@ -138,6 +138,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "d760b11b",
+   "metadata": {},
+   "source": [
+    "Below we explicitly specify `shots=1000` and `steps=100` respectively."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "id": "7a3ebaec",
@@ -153,7 +161,7 @@
    ],
    "source": [
     "start_time = time.time()\n",
-    "result_full = device.run(ahs_program, shots=1000).result()\n",
+    "result_full = device.run(ahs_program, shots=1000, steps=100).result()\n",
     "print(f\"The elapsed time = {time.time()-start_time} seconds\")"
    ]
   },
@@ -212,7 +220,7 @@
    ],
    "source": [
     "start_time = time.time()\n",
-    "result_blockade = device.run(ahs_program, shots=1000, blockade_radius=6.796e-6).result()\n",
+    "result_blockade = device.run(ahs_program, shots=1000, blockade_radius=6.796e-6, steps=100).result()\n",
     "print(f\"The elapsed time = {time.time()-start_time} seconds\")"
    ]
   },
@@ -294,7 +302,7 @@
    "source": [
     "## Tuning other parameters in the local simulator\n",
     "\n",
-    "Another way to speed up the simulation, without using the blockade approximation, is to adjust other parameters of the local simulator, such as `steps`, the number of time points in the simulation. It is set to `100` by default, but we can adjust it to `40` as shown below. We expect that the less time point used in the simulation, the faster it will finish."
+    "Another way to speed up the simulation, without using the blockade approximation, is to adjust other parameters of the local simulator, such as `steps`, the number of time points in the simulation. Previously, we have set `steps=100`, but it can be adjusted to be `40` as shown below. We expect that the less time point used in the simulation, the faster it will finish."
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

For the AHS notebooks that use local simulator, we manually set the time steps to 100 so that a) the user experience won't change and b) the integration tests can pass, if we change the default value of time steps in the local simulator. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
