### PR TITLE
fix: allow builds to be kicked off for .py files

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -9,12 +9,14 @@ on:
       - main
     paths: 
       - '*.yml'
+      - '*.py'
   pull_request:
     branches:
       - main
       - feature/**
     paths: 
       - '*.yml'
+      - '*.py'
 
 jobs:
   build:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Builds will be blocked from starting otherwise. Including `py` files will allow conda builds to start for prs that only change `py` files.

https://github.com/orgs/community/discussions/26698


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
