### PR TITLE
Replace ExpvalCost with qml.expval

### DIFF
--- a/examples/hybrid_jobs/2_Using_PennyLane_with_Braket_Jobs/qaoa/qaoa_algorithm_script.py
+++ b/examples/hybrid_jobs/2_Using_PennyLane_with_Braket_Jobs/qaoa/qaoa_algorithm_script.py
@@ -97,8 +97,12 @@ def main():
     dev = init_pl_device(device_arn, num_nodes, shots, max_parallel)
 
     np.random.seed(seed)
-    cost_function = qml.ExpvalCost(circuit, cost_h, dev, optimize=True, interface=pl_interface)
-
+    
+    @qml.qnode(dev, interface=pl_interface)
+    def cost_function(params, **kwargs):
+        circuit(params, **kwargs)
+        return qml.expval(cost_h)
+    
     # Load checkpoint if it exists
     if copy_checkpoints_from_job:
         checkpoint_1 = load_job_checkpoint(


### PR DESCRIPTION
*Description of changes:*

`qml.ExpvalCost` is deprecated; `qml.expval` is the correct method for returning expectation values.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
