### PR TITLE
fix: use sha256 hash instead of md5 and latest conda installer

### DIFF
--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -7,12 +7,12 @@ phases:
     commands:
       - _ANACONDA_ARCHIVE_URL=https://repo.anaconda.com/archive
       - _MINICONDA_ARCHIVE_URL=https://repo.anaconda.com/miniconda
-      - export LCC_CONDA_INSTALLER=Anaconda3-2023.03-Linux-x86_64.sh
+      - export LCC_CONDA_INSTALLER=Anaconda3-2023.03-1-Linux-x86_64.sh
       - export LCC_CONDA_INSTALLER_URL=$_ANACONDA_ARCHIVE_URL/$LCC_CONDA_INSTALLER
-      - export LCC_CONDA_INSTALLER_MD5=b4b52d8c977f4f7fd6079a77bac8641a
+      - export LCC_CONDA_INSTALLER_SHA256=95102d7c732411f1458a20bdf47e4c1b0b6c8a21a2edfe4052ca370aaae57bab
       - export LCC_CONDA_INSTALL_DIR=$HOME/Braket/anaconda3
       - wget --quiet $LCC_CONDA_INSTALLER_URL --output-document $LCC_CONDA_INSTALLER
-      - echo "$LCC_CONDA_INSTALLER_MD5  $LCC_CONDA_INSTALLER" | md5sum --status --check -
+      - echo "$LCC_CONDA_INSTALLER_SHA256  $LCC_CONDA_INSTALLER" | sha256sum --status --check -
       - chmod a+x $LCC_CONDA_INSTALLER
       - ./$LCC_CONDA_INSTALLER -b -p $LCC_CONDA_INSTALL_DIR
   pre_build:


### PR DESCRIPTION
https://docs.anaconda.com/free/anaconda/reference/hashes/all/

*Issue #, if available:*


*Description of changes:*
The previous version has an issue where py_310 is added to packages. Additionally, moving to SHA256 for better security.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
