### PR TITLE
Comment out QPU search cell in Qiskit notebook

### DIFF
--- a/examples/qiskit/0_Getting_Started.ipynb
+++ b/examples/qiskit/0_Getting_Started.ipynb
@@ -235,7 +235,7 @@
     }
    ],
    "source": [
-    "provider.backends(statuses=[\"ONLINE\"], types=[\"QPU\"])"
+    "# provider.backends(statuses=[\"ONLINE\"], types=[\"QPU\"])"
    ]
   },
   {


### PR DESCRIPTION
The Qiskit provider gets the JAQCD action for each device it finds in its search, and fails if this action isn't present. IonQ Aria does not support JAQCD, causing this notebook to fail.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
