### PR TITLE
Bump qiskit_braket_provider version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -31,6 +31,6 @@ dependencies:
       - pennylane==0.30.0
       - PennyLane-Lightning==0.30.0
       - qiskit-aer==0.12.0
-      - qiskit_braket_provider==0.0.3
+      - qiskit_braket_provider==0.0.4
       - qiskit-terra==0.23.3
       - scipy==1.9.3

--- a/examples/qiskit/0_Getting_Started.ipynb
+++ b/examples/qiskit/0_Getting_Started.ipynb
@@ -231,21 +231,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "f5329bca",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[BraketBackend[Aspen-M-3], BraketBackend[IonQ Device], BraketBackend[Lucy]]"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "provider.backends(statuses=[\"ONLINE\"], types=[\"QPU\"])"
    ]
@@ -292,7 +281,7 @@
    "source": [
     "qpu_backend = provider.get_backend(\"Aspen-M-3\")\n",
     "# qpu_backend = provider.get_backend(\"Lucy\")\n",
-    "# qpu_backend = provider.get_backend(\"IonQ Device\")\n",
+    "# qpu_backend = provider.get_backend(\"Aria\")\n",
     "\n",
     "print(qpu_backend)"
    ]

--- a/examples/qiskit/0_Getting_Started.ipynb
+++ b/examples/qiskit/0_Getting_Started.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "a477c993",
    "metadata": {
@@ -25,6 +26,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "c885d164",
    "metadata": {},
@@ -35,6 +37,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "b23c5287",
    "metadata": {
@@ -49,6 +52,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "a94feb7b",
    "metadata": {},
@@ -72,6 +76,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "17e2ab4d",
    "metadata": {},
@@ -92,6 +97,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "de912d0e",
    "metadata": {},
@@ -125,6 +131,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "d846e7f2",
    "metadata": {},
@@ -145,6 +152,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "41c66765",
    "metadata": {},
@@ -165,6 +173,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "ae97b1a1",
    "metadata": {},
@@ -175,6 +184,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "ad54a536",
    "metadata": {},
@@ -202,6 +212,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "dc6910f0",
    "metadata": {},
@@ -210,6 +221,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "8bfc8706",
    "metadata": {},
@@ -235,10 +247,11 @@
     }
    ],
    "source": [
-    "# provider.backends(statuses=[\"ONLINE\"], types=[\"QPU\"])"
+    "provider.backends(statuses=[\"ONLINE\"], types=[\"QPU\"])"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "4c7a21d4",
    "metadata": {},
@@ -248,6 +261,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "0800b99f",
    "metadata": {
@@ -261,6 +275,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "6bf048f4",
    "metadata": {},
@@ -340,6 +355,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "9515c95b",
    "metadata": {},
@@ -370,6 +386,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "3b7ee5ac",
    "metadata": {},
@@ -391,6 +408,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "355472d4",
    "metadata": {},
@@ -420,6 +438,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "7c2d97be",
    "metadata": {},
@@ -428,6 +447,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "d6f54cb5",
    "metadata": {},
@@ -457,6 +477,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "1819e1f8",
    "metadata": {
@@ -469,6 +490,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "41520df9",
    "metadata": {},
@@ -526,6 +548,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "a5ce5134",
    "metadata": {},
@@ -534,6 +557,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "a497c6ef",
    "metadata": {},


### PR DESCRIPTION
*Description of changes:*
* Bumping qiskit_braket_provider from `0.0.3` to `0.0.4` to release. This fixes an issue with the new Aria device not supporting JAQCD (https://github.com/qiskit-community/qiskit-braket-provider/pull/104)
* Uncommented a disabled cell in the Qiskit example NBI


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
