### PR TITLE
Update and rename Allocating_Qubits_on_QPU_Devices.ipynb to Allocatin…

### DIFF
--- a/examples/braket_features/Allocating_Qubits_on_Rigetti_QPU_Devices.ipynb
+++ b/examples/braket_features/Allocating_Qubits_on_Rigetti_QPU_Devices.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Allocating Qubits on QPU Devices"
+    "# Allocating Qubits on Rigetti QPU Devices"
    ]
   },
   {


### PR DESCRIPTION
…g_Qubits_on_Rigetti_QPU_Devices.ipynb

The notebook title is too generic for what it contains. Suggesting more specificity (i.e. "Rigetti QPU devices" instead of "QPU devices") to aid in content discovery.

*Issue #, if available:*

*Description of changes:*
Updated title to help with content discovery and to more accurately reflect notebook contents

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
