### PR TITLE
Remove deprecated qml.grouping

### DIFF
--- a/examples/pennylane/3_Hydrogen_Molecule_geometry_with_VQE/3_Hydrogen_Molecule_geometry_with_VQE.ipynb
+++ b/examples/pennylane/3_Hydrogen_Molecule_geometry_with_VQE/3_Hydrogen_Molecule_geometry_with_VQE.ipynb
@@ -535,7 +535,7 @@
     }
    ],
    "source": [
-    "groups, coeffs = qml.grouping.group_observables(h.ops, h.coeffs)\n",
+    "groups, coeffs = qml.pauli.group_observables(h.ops, h.coeffs)\n",
     "print(\"Number of qubit-wise commuting groups:\", len(groups))"
    ]
   },
@@ -683,7 +683,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
*Description of changes:*
`qml.grouping` is deprecated in v0.31, causing a notebook to fail. Replace `qml.grouping` with ` qml.pauli`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
