### PR TITLE
Update pennylane version

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -18,11 +18,11 @@ jobs:
 
     steps:
     - name: Maximize build space
-      uses: easimon/maximize-build-space@master
-      with:
-        root-reserve-mb: 512
-        swap-size-mb: 1024
-        remove-android: 'true'
+      shell: bash
+      run: |
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/ghc
     - uses: actions/checkout@v2
     - name: Setup python 3.8
       uses: actions/setup-python@v2

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -17,10 +17,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Free Disk Space
-      uses: jlumbroso/free-disk-space@main
+    - name: Maximize build space
+      uses: easimon/maximize-build-space@master
       with:
-        tool-cache: false
+        root-reserve-mb: 512
+        swap-size-mb: 1024
+        remove-android: 'true'
     - uses: actions/checkout@v2
     - name: Setup python 3.8
       uses: actions/setup-python@v2

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -17,6 +17,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Free Disk Space
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: false
     - uses: actions/checkout@v2
     - name: Setup python 3.8
       uses: actions/setup-python@v2

--- a/environment.yml
+++ b/environment.yml
@@ -28,7 +28,7 @@ dependencies:
       - oqpy==0.1.1
       - numpy==1.23.5
       - pandas==2.0.0
-      - pennylane==0.30.0
+      - pennylane==0.31.0
       - PennyLane-Lightning==0.30.0
       - qiskit-aer==0.12.0
       - qiskit_braket_provider==0.0.4

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
       - awscli==1.27.65
       - boto3==1.26.64
       - amazon-braket-default-simulator==1.16.0
-      - amazon-braket-pennylane-plugin==1.17.0
+      - amazon-braket-pennylane-plugin==1.17.2
       - amazon-braket-schemas==1.17.0
       - amazon-braket-sdk==1.47.0
       - amazon-braket-algorithm-library==1.3.2
@@ -29,7 +29,7 @@ dependencies:
       - numpy==1.23.5
       - pandas==2.0.0
       - pennylane==0.31.0
-      - PennyLane-Lightning==0.30.0
+      - PennyLane-Lightning==0.31.0
       - qiskit-aer==0.12.0
       - qiskit_braket_provider==0.0.4
       - qiskit-terra==0.23.3

--- a/examples/pennylane/3_Hydrogen_Molecule_geometry_with_VQE/3_Hydrogen_Molecule_geometry_with_VQE.ipynb
+++ b/examples/pennylane/3_Hydrogen_Molecule_geometry_with_VQE/3_Hydrogen_Molecule_geometry_with_VQE.ipynb
@@ -535,7 +535,7 @@
     }
    ],
    "source": [
-    "groups, coeffs = qml.grouping.group_observables(h.ops, h.coeffs)\n",
+    "groups, coeffs = qml.pauli.group_observables(h.ops, h.coeffs)\n",
     "print(\"Number of qubit-wise commuting groups:\", len(groups))"
    ]
   },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Upgrading to the latest PL versions
* Update the VQE example to reference the new location for the `group_observables` method.
* Update the conda build Github action to remove unused libraries to create more space for the build action which were failing because they were running out of space on the Github runners. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
