### PR TITLE
fix: updating awscli to awscli2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
   - defaults
 dependencies:
   - python=3.10
+  - pip>=23.0
   - pip:
       - botocore==1.29.65
       - awscli==1.27.65

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip>=23.0
   - pip:
       - botocore==1.29.65
-      - awscli==1.27.65
+      - awscliv2==2.2.0
       - boto3==1.26.64
       - amazon-braket-default-simulator==1.16.0
       - amazon-braket-pennylane-plugin==1.17.0
@@ -35,4 +35,3 @@ dependencies:
       - qiskit_braket_provider==0.0.4
       - qiskit-terra==0.23.3
       - scipy==1.9.3
-      - PyYAML==5.4

--- a/environment.yml
+++ b/environment.yml
@@ -34,3 +34,4 @@ dependencies:
       - qiskit_braket_provider==0.0.4
       - qiskit-terra==0.23.3
       - scipy==1.9.3
+      - PyYAML==5.4


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-cli/issues/8036#issuecomment-1638544754

An issue with AWS CLI is causing builds to fail. The recommended action is to move to awscliv2. 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
