### PR TITLE
fix: remove redundant whitespace

### DIFF
--- a/examples/braket_features/Getting_notifications_when_a_task_completes/Getting_notifications_when_a_task_completes.ipynb
+++ b/examples/braket_features/Getting_notifications_when_a_task_completes/Getting_notifications_when_a_task_completes.ipynb
@@ -51,7 +51,7 @@
     "\n",
     "After the key is created, you must edit the default Key Policy to include S3 and SNS services as Principals that can encrypt and decrypt data. Add the following permission within the \"Statement\" list (remember to replace the &lt;CMK ARN&gt; into the ARN of the key)\n",
     "    \n",
-    "```        \n",
+    "```\n",
     "{\n",
     "    \"Sid\": \"Allow access for S3 and SNS (as Service Principals)\",\n",
     "    \"Effect\": \"Allow\",\n",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* The library used to render markdown to html (mistune) fails due to the additional whitespace around the code block causing the notebook to not be rendered on github. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
