### PR TITLE
Increase compression level for conda pack

### DIFF
--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -28,7 +28,7 @@ phases:
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package
       - conda list
-      - conda pack --name $BRAKET_ENV --output envs/Braket.tgz
+      - conda pack --name $BRAKET_ENV --output envs/Braket.tgz --compress-level 9 
 
 artifacts:
   files:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Increase compression level for the conda environment compressed archive. This reduces the size of the compressed file by 5%. While the compression time is longer, the time to decompress is about the same. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
