### PR TITLE
fix: exclude .rst files when packing the env

### DIFF
--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -28,7 +28,7 @@ phases:
       - conda config --set path_conflict warn
       - conda env create --name $BRAKET_ENV -f environment.yml --no-default-package
       - conda list
-      - conda pack --name $BRAKET_ENV --output envs/Braket.tgz --compress-level 9 
+      - conda pack --name $BRAKET_ENV --output envs/Braket.tgz --compress-level 9 --exclude *.rst
 
 artifacts:
   files:


### PR DESCRIPTION
Currently, there are around 5000 `.rst` files packed in the env. This will cut down on the artifact size as well as slightly reduce unpacking the files.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
