### PR TITLE
fix: use the locally downloaded image instead of defaulting to the la…

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -33,4 +33,4 @@ jobs:
         docker pull public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:3.0
     - name: Build conda environment
       run: |
-        ./nbi/codebuild_build.sh -i public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:3.0 -a envs -b nbi/buildspec.yml -l public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        ./nbi/codebuild_build.sh -i test -a envs -b nbi/buildspec.yml -l public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:3.0

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -28,9 +28,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.8
-    - name: Pull codebuild docker image
-      run: |
-        docker pull public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:3.0
     - name: Build conda environment
       run: |
-        ./nbi/codebuild_build.sh -a envs -b nbi/buildspec.yml -l public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        ./nbi/codebuild_build.sh -i public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:3.0 -a envs -b nbi/buildspec.yml

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -33,4 +33,4 @@ jobs:
         docker pull public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:3.0
     - name: Build conda environment
       run: |
-        ./nbi/codebuild_build.sh -i test -a envs -b nbi/buildspec.yml -l public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        ./nbi/codebuild_build.sh -a envs -b nbi/buildspec.yml -l public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:3.0

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -33,4 +33,4 @@ jobs:
         docker pull public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:3.0
     - name: Build conda environment
       run: |
-        ./nbi/codebuild_build.sh -i public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:3.0 -a envs -b nbi/buildspec.yml
+        ./nbi/codebuild_build.sh -i public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:3.0 -a envs -b nbi/buildspec.yml -l public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:3.0

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
       - amazon-braket-default-simulator==1.18.2
       - amazon-braket-pennylane-plugin==1.17.4
       - amazon-braket-schemas==1.19.0
-      - amazon-braket-sdk==1.53.3
+      - amazon-braket-sdk==1.49.1
       - amazon-braket-algorithm-library==1.4.0
       - cvxpy==1.3.1
       - dask==2023.1.1

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
       - amazon-braket-default-simulator==1.18.2
       - amazon-braket-pennylane-plugin==1.17.4
       - amazon-braket-schemas==1.19.0
-      - amazon-braket-sdk==1.49.1
+      - amazon-braket-sdk==1.53.3
       - amazon-braket-algorithm-library==1.4.0
       - cvxpy==1.3.1
       - dask==2023.1.1


### PR DESCRIPTION
…test from the ECR repo


```
docker run -i -v /var/run/docker.sock:/var/run/docker.sock -e "IMAGE_NAME=public.ecr.aws/codebuild/amazonlinux2-x86_64-standard:3.0" -e "ARTIFACTS=/home/runner/work/amazon-braket-examples/amazon-braket-examples/envs" -e "SOURCE=/home/runner/work/amazon-braket-examples/amazon-braket-examples" -e "BUILDSPEC=/home/runner/work/amazon-braket-examples/amazon-braket-examples/nbi/buildspec.yml" -e "INITIATOR=runner" public.ecr.aws/codebuild/local-builds:latest
```
Current behavior does not set the image to use (`-l`) so we fall back to pulling a [new image](https://github.com/aws/amazon-braket-examples/blob/2a4fb53e85e346f42401132252abab17a9e85f5e/nbi/codebuild_build.sh#L195)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
