### PR TITLE
update: add test for conversion to html

### DIFF
--- a/test/integ_tests/requirements.txt
+++ b/test/integ_tests/requirements.txt
@@ -2,6 +2,7 @@ amazon-braket-sdk
 amazon-braket-pennylane-plugin
 cvxpy
 matplotlib
+nbconvert
 pandas
 pennylane
 pytest

--- a/test/integ_tests/test_all_notebooks.py
+++ b/test/integ_tests/test_all_notebooks.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 from testbook import testbook
+from nbconvert import HTMLExporter
 from importlib.machinery import SourceFileLoader
 
 # These notebooks have syntax or dependency issues that prevent them from being tested.
@@ -72,6 +73,16 @@ def test_all_notebooks(notebook_dir, notebook_file, mock_level):
         tb.execute()
         test_mocks = SourceFileLoader("notebook_mocks", path_to_mocks).load_module()
         test_mocks.post_run(tb)
+
+
+@pytest.mark.parametrize("notebook_dir, notebook_file", test_notebooks)
+def test_notebook_to_html_conversion(notebook_dir, notebook_file, mock_level):
+    os.chdir(root_path)
+    os.chdir(notebook_dir)
+
+    html_exporter = HTMLExporter(template_name='classic')
+
+    html_exporter.from_file(notebook_file)
 
 
 def test_record():


### PR DESCRIPTION
*Issue #, if available:*
This is in response to [this issue](https://github.com/aws/amazon-braket-examples/pull/318) where one of our notebooks was not rendering properly in GitHub. With this change, whenever we run our integration tests we'll also test if the notebooks can be converted to HTML.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
