### PR TITLE
fix: hello cudaq image region for emerald

### DIFF
--- a/examples/nvidia_cuda_q/0_hello_cudaq_jobs.ipynb
+++ b/examples/nvidia_cuda_q/0_hello_cudaq_jobs.ipynb
@@ -183,7 +183,9 @@
    "id": "ee3996aa-195b-45d7-a007-077a0d557b9f",
    "metadata": {},
    "source": [
-    "Now, let’s learn how to run CUDA-Q programs on Braket devices via CUDA-Q in Braket Hybrid Jobs. All you need to do is to configure the CUDA-Q target to a Braket device. In the code snippet below, we run a Bell circuit on Braket SV1 using CUDA-Q and Braket Hybrid Jobs. When you finish testing on simulators and are ready to run experiments on QPUs, you can switch the target to Braket QPUs such as IQM, IonQ, and Rigetti devices by changing `device_arn` in the example below. The circuits run with a hybrid job receive higher-priority access to the target Braket QPUs, which not only reduces the runtime of your experiments but also minimizes the impact of hardware drift on your algorithms. "
+    "Now, let’s learn how to run CUDA-Q programs on Braket devices via CUDA-Q in Braket Hybrid Jobs. All you need to do is (1) configure the CUDA-Q target to a Braket device and (2) select the appropriate region image (so that it matches the device). \n",
+    "\n",
+    "In the code snippet below, we run a Bell circuit on Braket SV1 using CUDA-Q and Braket Hybrid Jobs. When you finish testing on simulators and are ready to run experiments on QPUs, you can switch the target to Braket QPUs such as IQM, IonQ, and Rigetti devices by changing `device_arn` in the example below. The circuits run with a hybrid job receive higher-priority access to the target Braket QPUs, which not only reduces the runtime of your experiments but also minimizes the impact of hardware drift on your algorithms. "
    ]
   },
   {
@@ -195,7 +197,7 @@
    "source": [
     "device_arn = \"arn:aws:braket:::device/quantum-simulator/amazon/sv1\"  # set device to SV1\n",
     "# device_arn = \"arn:aws:braket:eu-north-1::device/qpu/iqm/Garnet\" # set device to IQM Garnet\n",
-    "\n",
+    "# image_uri = retrieve_image(Framework.CUDAQ, \"eu-north-1\") # get image from eu-north-1\n",
     "\n",
     "@hybrid_job(device=device_arn, image_uri=image_uri)\n",
     "def job_with_braket_device():\n",


### PR DESCRIPTION
*Issue #, if available:*

Incorrect region for the cuda-q image when selecting Emerald device in the cuda_q notebook. 

*Description of changes:*

Added short description and another commented line of code. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
