### PR TITLE
fix: Update openfermion version to 1.7.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ mistune==3.0.2 # pin until https://github.com/lepture/mistune/issues/403 is reso
 ml-dtypes==0.5.1 # pinned for build compatibility
 mypy-extensions==1.1.0
 numpy==2.2.6 # Numpy 2.3.x requires Python >=3.11
-openfermion==1.6.1
+openfermion==1.7.1
 openfermionpyscf==0.5
 optax==0.2.6
 pandas==2.3.3


### PR DESCRIPTION
*Issue #, if available:*
Braket notebook instances encounter and error running the notebook https://github.com/amazon-braket/amazon-braket-examples/blob/main/examples/hybrid_quantum_algorithms/VQE_Chemistry/VQE_chemistry_braket.ipynb due to incompatibility with numpy v2.2.6.
```
AttributeError: `np.string_` was removed in the NumPy 2.0 release. Use `np.bytes_` instead.
```

*Description of changes:*
Upgrade openfermion version in Braket notebook instances to fix compatibility with numpy v2.2.6.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
