### PR TITLE
Add notes for allowed parameter ranges for different noise channels

### DIFF
--- a/examples/braket_features/Simulating_Noise_On_Amazon_Braket.ipynb
+++ b/examples/braket_features/Simulating_Noise_On_Amazon_Braket.ipynb
@@ -462,6 +462,7 @@
    "outputs": [],
    "source": [
     "from braket.circuits.gates import X, Y, Z\n",
+    "\n",
     "EX = X().to_matrix() / np.sqrt(3)\n",
     "EY = Y().to_matrix() / np.sqrt(3)\n",
     "EZ = Z().to_matrix() / np.sqrt(3)\n",


### PR DESCRIPTION
*Issue #, if available:*

The allowed parameter ranges of the built-in noise channels were not indicated clearly.

*Description of changes:*

We add the allowed parameter ranges for the built-in noise channels and explain their physical meanings. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
