### PR TITLE
Correct terminology from post-measurement to pre-measurement

### DIFF
--- a/examples/advanced_circuits_algorithms/Randomness/Randomness_Generation.ipynb
+++ b/examples/advanced_circuits_algorithms/Randomness/Randomness_Generation.ipynb
@@ -127,7 +127,7 @@
     "* Apply the Hadamard gate $H=\\frac{1}{\\sqrt{2}}\\begin{pmatrix} 1 & 1\\\\ 1 & 1 \\end{pmatrix}$ leading to the state vector $|H\\rangle=\\frac{1}{\\sqrt{2}}\\big(|0\\rangle+|1\\rangle\\big)$\n",
     "* Measure in the computational basis $\\big\\{|0\\rangle\\langle0|,|1\\rangle\\langle1|\\big\\}$.\n",
     "\n",
-    "By the laws of quantum physics, the post-measurement probability distribution is then the uniformly distributed $(1/2,1/2)$ and leads to one random bit $0/1$.\n",
+    "By the laws of quantum physics, the pre-measurement probability distribution is then the uniformly distributed $(1/2,1/2)$ and leads to one random bit $0/1$.\n",
     "\n",
     "In the following, we discuss how above protocol is conceptually different from randomness obtained from classical sources and show in detail how it is implemented reliable even when the underlying quantum processing units employed are noisy. By the end of this tutorial, you will be able to create your own random bits from the quantum processing units available on Amazon Braket.\n",
     "\n",


### PR DESCRIPTION
Measurement will collapse the probability to 1 in one state and 0 in the other.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
