### PR TITLE
fix: preserve numpy test modules in conda environment build

### DIFF
--- a/nbi/buildspec.yml
+++ b/nbi/buildspec.yml
@@ -40,6 +40,7 @@ phases:
         find $_ENV_PATH/lib/python*/site-packages -type d \( -name "tests" -o -name "test" \) | \
         grep -v "amazon_braket" | \
         grep -v "braket" | \
+        grep -v "numpy" | \
         xargs rm -rf 2>/dev/null || true
       - conda pack --quiet --name $BRAKET_ENV --output envs/Braket.tar.zst 
           --compress-level 3 --n-threads -1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Exclude numpy from test directory cleanup to prevent removal of numpy._core.tests, which is required by scipy's array_api_compat. This fixes ModuleNotFoundError during NBI integration tests.
