### PR TITLE
test: exclude notebook that runs into timeouts

### DIFF
--- a/test/integ_tests/test_all_notebooks.py
+++ b/test/integ_tests/test_all_notebooks.py
@@ -40,6 +40,8 @@ EXCLUDED_NOTEBOOKS = [
     "TN1_demo_local_vs_non-local_random_circuits.ipynb",
     # Dynamic circuits with QBP
     "4_Dynamic_Circuits_with_Qiskit_Braket_Provider.ipynb",
+    # Investigating local simulator performance on small circuits
+    "02_Expectation_value_calculations_with_program_sets.ipynb",
     # TODO: Add spending limit mocks
     "Spending_Limits_Introduction.ipynb",
     "0_Getting_started_with_mitiq_on_Braket.ipynb",


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
- This notebook runs into timeout error, and needs more investigation before enabling. Temporary excluding the workflow to allow other changes to be released. 
- Reverts this PR when this was added: https://github.com/amazon-braket/amazon-braket-examples/pull/861/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
