### PR TITLE
fix: re-enable 3 Ankaa-3 device notebooks in test suite

### DIFF
--- a/test/integ_tests/braket_features/Allocating_Qubits_on_QPU_Devices_mocks.py
+++ b/test/integ_tests/braket_features/Allocating_Qubits_on_QPU_Devices_mocks.py
@@ -1,0 +1,21 @@
+def pre_run_inject(mock_utils):
+    mocker = mock_utils.Mocker()
+    mock_utils.mock_default_device_calls(mocker)
+    mocker.set_get_device_result(
+        {
+            "deviceType": "QPU",
+            "providerName": "Rigetti",
+            "deviceCapabilities": mock_utils.read_file("ankaa3_device_capabilities.json"),
+            "deviceQueueInfo": [
+                {"queue": "QUANTUM_TASKS_QUEUE", "queueSize": "0", "queuePriority": "Normal"},
+                {"queue": "QUANTUM_TASKS_QUEUE", "queueSize": "0", "queuePriority": "Priority"},
+                {"queue": "JOBS_QUEUE", "queueSize": "0"},
+            ],
+        },
+    )
+    mocker.set_task_result_return(mock_utils.read_file("default_results.json"))
+
+
+def post_run(tb):
+    pass
+

--- a/test/integ_tests/braket_features/Device_emulation/01_Local_Emulation_for_Verbatim_Circuits_on_Amazon_Braket_mocks.py
+++ b/test/integ_tests/braket_features/Device_emulation/01_Local_Emulation_for_Verbatim_Circuits_on_Amazon_Braket_mocks.py
@@ -1,0 +1,21 @@
+def pre_run_inject(mock_utils):
+    mocker = mock_utils.Mocker()
+    mock_utils.mock_default_device_calls(mocker)
+    mocker.set_get_device_result(
+        {
+            "deviceType": "QPU",
+            "providerName": "Rigetti",
+            "deviceCapabilities": mock_utils.read_file("ankaa3_device_capabilities.json"),
+            "deviceQueueInfo": [
+                {"queue": "QUANTUM_TASKS_QUEUE", "queueSize": "0", "queuePriority": "Normal"},
+                {"queue": "QUANTUM_TASKS_QUEUE", "queueSize": "0", "queuePriority": "Priority"},
+                {"queue": "JOBS_QUEUE", "queueSize": "0"},
+            ],
+        },
+    )
+    mocker.set_task_result_return(mock_utils.read_file("default_results.json"))
+
+
+def post_run(tb):
+    pass
+

--- a/test/integ_tests/braket_features/Noise_models/Noise_models_on_Rigetti_mocks.py
+++ b/test/integ_tests/braket_features/Noise_models/Noise_models_on_Rigetti_mocks.py
@@ -1,0 +1,21 @@
+def pre_run_inject(mock_utils):
+    mocker = mock_utils.Mocker()
+    mock_utils.mock_default_device_calls(mocker)
+    mocker.set_get_device_result(
+        {
+            "deviceType": "QPU",
+            "providerName": "Rigetti",
+            "deviceCapabilities": mock_utils.read_file("ankaa3_device_capabilities.json"),
+            "deviceQueueInfo": [
+                {"queue": "QUANTUM_TASKS_QUEUE", "queueSize": "0", "queuePriority": "Normal"},
+                {"queue": "QUANTUM_TASKS_QUEUE", "queueSize": "0", "queuePriority": "Priority"},
+                {"queue": "JOBS_QUEUE", "queueSize": "0"},
+            ],
+        },
+    )
+    mocker.set_task_result_return(mock_utils.read_file("default_results.json"))
+
+
+def post_run(tb):
+    pass
+

--- a/test/integ_tests/test_all_notebooks.py
+++ b/test/integ_tests/test_all_notebooks.py
@@ -30,11 +30,8 @@ EXCLUDED_NOTEBOOKS = [
     "5_Multiple_GPU_simulations.ipynb",
     "6_Distributed_state_vector_simulations.ipynb",
     # Notebooks that require devices to be online
-    "Allocating_Qubits_on_QPU_Devices.ipynb",
-    "Noise_models_on_Rigetti.ipynb",
     "2_Running_quantum_circuits_on_QPU_devices.ipynb",
     "Verbatim_Compilation.ipynb",
-    "01_Local_Emulation_for_Verbatim_Circuits_on_Amazon_Braket.ipynb",
     # Simulator TN1 notebook, remove when TN1 issues are fixed
     "TN1_demo_local_vs_non-local_random_circuits.ipynb",
     # Dynamic circuits with QBP


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
Remove Allocating_Qubits_on_QPU_Devices, Noise_models_on_Rigetti, and 01_Local_Emulation_for_Verbatim_Circuits from EXCLUDED_NOTEBOOKS. Add mock files referencing shared ankaa3_device_capabilities.json.

Verified passing in NBI pipeline with --mock-level=LEAST.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
