### PR TITLE
fix: re-enable VQE_chemistry_braket notebook in test suite

### DIFF
--- a/test/integ_tests/test_all_notebooks.py
+++ b/test/integ_tests/test_all_notebooks.py
@@ -15,7 +15,6 @@ EXCLUDED_NOTEBOOKS = [
     "bring_your_own_container.ipynb",
     "qnspsa_with_embedded_simulator.ipynb",
     # These notebooks have dependency issues
-    "VQE_chemistry_braket.ipynb",
     "6_Adjoint_gradient_computation.ipynb",
     # These notebooks are run from within a job (see Running_notebooks_as_hybrid_jobs.ipynb)
     "0_Getting_started_papermill.ipynb",


### PR DESCRIPTION
The notebook was excluded since Dec 2022 for missing openfermion/pyscf dependencies, but these were added to requirements.txt in Sep 2023. Verified passing in NBI pipeline with --mock-level=LEAST.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
