### PR TITLE
fix: re-enable expectation value notebook with increased timeout

### DIFF
--- a/test/integ_tests/test_all_notebooks.py
+++ b/test/integ_tests/test_all_notebooks.py
@@ -9,6 +9,13 @@ from testbook import testbook
 
 UNCOMMENT_NOTEBOOK_TAG = "## UNCOMMENT_TO_RUN"
 
+DEFAULT_CELL_TIMEOUT = 600
+
+# Notebooks that need longer cell timeout due to heavy local simulation
+NOTEBOOK_TIMEOUTS = {
+    "02_Expectation_value_calculations_with_program_sets.ipynb": 900,
+}
+
 # These notebooks have syntax or dependency issues that prevent them from being tested.
 EXCLUDED_NOTEBOOKS = [
     # These notebooks have cells that have syntax errors
@@ -35,8 +42,6 @@ EXCLUDED_NOTEBOOKS = [
     "TN1_demo_local_vs_non-local_random_circuits.ipynb",
     # Dynamic circuits with QBP
     "4_Dynamic_Circuits_with_Qiskit_Braket_Provider.ipynb",
-    # Investigating local simulator performance on small circuits
-    "02_Expectation_value_calculations_with_program_sets.ipynb",
     "0_Getting_started_with_mitiq_on_Braket.ipynb",
     "1_Readout_mitigation_with_mitiq.ipynb",
     "2_Zero_noise_extrapolation_with_mitiq.ipynb",
@@ -97,7 +102,7 @@ def test_all_notebooks(notebook_dir, notebook_file, mock_level):
     path_to_utils, path_to_mocks = get_mock_paths(notebook_dir, notebook_file)
     # Try to use the conda_braket kernel if installed, otherwise fall back to the default value of python3
     kernel = "conda_braket" if "conda_braket" in kernelspec.find_kernel_specs() else "python3"
-    with testbook(notebook_file, timeout=600, kernel_name=kernel) as tb:
+    with testbook(notebook_file, timeout=NOTEBOOK_TIMEOUTS.get(notebook_file, DEFAULT_CELL_TIMEOUT), kernel_name=kernel) as tb:
         # We check the existing notebook output for errors before we execute the
         # notebook because it will change after executing it.
         check_cells_for_error_output(tb.cells)
@@ -132,7 +137,7 @@ def test_record():
     path_to_utils = path_to_utils.replace("mock_utils.py", "record_utils.py")
     # Try to use the conda_braket kernel if installed, otherwise fall back to the default value of python3
     kernel = "conda_braket" if "conda_braket" in kernelspec.find_kernel_specs() else "python3"
-    with testbook(notebook_file, timeout=600, kernel_name=kernel) as tb:
+    with testbook(notebook_file, timeout=NOTEBOOK_TIMEOUTS.get(notebook_file, DEFAULT_CELL_TIMEOUT), kernel_name=kernel) as tb:
         tb.inject(
             f"""
             from importlib.machinery import SourceFileLoader


### PR DESCRIPTION
Remove 02_Expectation_value_calculations_with_program_sets.ipynb from EXCLUDED_NOTEBOOKS. The notebook runs 100 trials of local simulator computations which takes 567-726s, exceeding the 600s per-cell timeout.

Add per-notebook timeout configuration (NOTEBOOK_TIMEOUTS) and set this notebook's timeout to 900s. This also fixes the prod NBI pipeline failure caused by PR #861 un-excluding it without addressing the timeout.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
