### PR TITLE
fix: re-enable AHS local simulator notebook in test suite

### DIFF
--- a/test/integ_tests/test_all_notebooks.py
+++ b/test/integ_tests/test_all_notebooks.py
@@ -18,8 +18,6 @@ EXCLUDED_NOTEBOOKS = [
     "6_Adjoint_gradient_computation.ipynb",
     # These notebooks are run from within a job (see Running_notebooks_as_hybrid_jobs.ipynb)
     "0_Getting_started_papermill.ipynb",
-    # Some AHS examples are running long especially on Mac. Removing while investigating
-    "05_Running_Analog_Hamiltonian_Simulation_with_local_simulator.ipynb",
     # Requires amazon-braket-simulator-v2 package (optional install)
     "Using_the_experimental_local_simulator.ipynb",
     # CUDA-Q hybrid job notebooks


### PR DESCRIPTION
Remove 05_Running_Analog_Hamiltonian_Simulation_with_local_simulator.ipynb from EXCLUDED_NOTEBOOKS. Was excluded for 'running long on Mac' but completed in 21s in NBI pipeline. Uses only LocalSimulator with no AWS API calls.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
