### PR TITLE
fix: update Adjoint gradient notebook for PennyLane API change

### DIFF
--- a/examples/pennylane/6_Adjoint_gradient_computation/6_Adjoint_gradient_computation.ipynb
+++ b/examples/pennylane/6_Adjoint_gradient_computation/6_Adjoint_gradient_computation.ipynb
@@ -561,8 +561,7 @@
     "best_energy = 0.0\n",
     "for n in range(iterations):\n",
     "    print(f\"Iteration {n} of full optimization.\")\n",
-    "    params, energy = opt.step_and_cost(circuit_1, params, excitations=gates_select)\n",
-    "    best_energy = energy.numpy()"
+    "    params, best_energy = opt.step_and_cost(circuit_1, params, excitations=gates_select)"
    ]
   },
   {


### PR DESCRIPTION
opt.step_and_cost() now returns numpy.ndarray instead of pennylane.numpy.tensor, causing AttributeError on .numpy() call. Simplified by unpacking cost directly into best_energy.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
