### PR TITLE
fix: clean up test artifacts between runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,12 +138,14 @@ dmypy.json
 
 # Data intermediates
 *.pck
+examples/analog_hamiltonian_simulation/task_arns.npy
 examples/hybrid_jobs/2_Using_PennyLane_with_Braket_Jobs/input-data.adjlist
 
 # Notebook artifacts
 */3_Deep_dive_into_the_anatomy_of_quantum_circuits/device_logs-*.txt
 examples/hybrid_jobs/4_Embedded_simulators_in_Braket_Hybrid_Jobs/embedded-simulation-*
 examples/hybrid_jobs/8_Creating_Hybrid_Job_Scripts/braket-job-default-*
+examples/hybrid_quantum_algorithms/VQE_Chemistry/data
 examples/nvidia_cuda_q/cuda-q-applications*
 examples/nvidia_cuda_q/cuda-q-academic*
 examples/**/model.tar.gz

--- a/test/integ_tests/conftest.py
+++ b/test/integ_tests/conftest.py
@@ -1,4 +1,6 @@
+import glob
 import os
+import shutil
 
 import pytest
 from nbconvert import HTMLExporter
@@ -8,6 +10,18 @@ if "integ_tests" in os.getcwd():
 
 root_path = os.getcwd()
 
+
+def _remove_test_artifacts():
+    test_artifact_globs = (
+        os.path.join(root_path, "examples", "nvidia_cuda_q", "cuda-q-applications*"),
+        os.path.join(root_path, "examples", "nvidia_cuda_q", "cuda-q-academic*"),
+    )
+    for pattern in test_artifact_globs:
+        for path in glob.glob(pattern):
+            shutil.rmtree(path, ignore_errors=True)
+
+
+_remove_test_artifacts()
 
 
 def pytest_addoption(parser):
@@ -43,6 +57,7 @@ def restore_cwd():
     """ after each test, move back to root_path - amazon-braket-examples/"""
     yield
     os.chdir(root_path)
+    _remove_test_artifacts()
     
 @pytest.fixture(scope="module")
 def html_exporter():


### PR DESCRIPTION
*Issue #, if available:*
Fixes #880

*Description of changes:*
Two CUDA-Q notebooks clone external repositories into the examples tree. This fix cleans these directories at conftest import time (before test collection) and inside the existing autouse restore_cwd fixture (between tests), so artifacts never persist across or within sessions.

Also adds a couple of paths to .gitignore to avoid test artifacts from polluting git status.

*Testing done:*
Consecutive `hatch run test` calls pass successfully with no untracked changes in the git tree.


## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-examples/blob/main/CONTRIBUTING.md) doc
- [x] I have read [docs/INSTRUCTIONS.md](https://github.com/amazon-braket/amazon-braket-examples/blob/main/docs/INSTRUCTIONS.md) and if necessary, added to `docs/ENTRIES.json` and run `docs/build_readme.sh`

#### Tests

- [x] I have verified my changes pass `pytest test/` (see [TESTING.md](https://github.com/amazon-braket/amazon-braket-examples/blob/main/TESTING.md))
- [x] If adding to `EXCLUDED_NOTEBOOKS`, I have included reason in the comment (e.g. `# Reason: requires GPU runtime`)
- [x] If modifying a notebook, I have verified no broken outputs or missing imports

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
