### PR TITLE
test: Re-enable 0_Getting_started_with_CUDA-Q.ipynb in NBI tests

### DIFF
--- a/test/integ_tests/nvidia_cuda_q/0_Getting_started_with_CUDA-Q_mocks.py
+++ b/test/integ_tests/nvidia_cuda_q/0_Getting_started_with_CUDA-Q_mocks.py
@@ -1,0 +1,18 @@
+def pre_run_inject(mock_utils):
+    mocker = mock_utils.Mocker()
+    mock_utils.mock_default_device_calls(mocker)
+    # In ALL mode (GitHub CI), cudaq.set_target("braket") would fail without
+    # AWS credentials. Patch it to use emulate=True so it runs locally via
+    # the CUDA-Q simulator. In LEAST mode (NBI pipeline), the real Braket
+    # path is tested with MOCK_DEVICE_CONFIG handling device routing.
+    if mock_utils.Mocker.mock_level == "ALL":
+        import cudaq
+        _real = cudaq.set_target
+        def _wrapped(*a, **kw):
+            kw.setdefault("emulate", True)
+            return _real(*a, **kw)
+        cudaq.set_target = _wrapped
+
+
+def post_run(tb):
+    pass

--- a/test/integ_tests/test_all_notebooks.py
+++ b/test/integ_tests/test_all_notebooks.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+import sys
 from importlib.machinery import SourceFileLoader
 
 import pytest
@@ -27,8 +28,7 @@ EXCLUDED_NOTEBOOKS = [
     "0_Getting_started_papermill.ipynb",
     # Requires amazon-braket-simulator-v2 package (optional install)
     "Using_the_experimental_local_simulator.ipynb",
-    # CUDA-Q hybrid job notebooks
-    "0_Getting_started_with_CUDA-Q.ipynb",
+    # CUDA-Q notebooks that require GPU/CUDA-Q runtime
     "3_Hybrid_jobs_with_CUDA-Q.ipynb",
     "4_Simulation_with_GPUs.ipynb",
     "5_Multiple_GPU_simulations.ipynb",
@@ -60,6 +60,10 @@ if (
         "0_Creating_your_first_Hybrid_Job.ipynb",
     ]
     EXCLUDED_NOTEBOOKS.extend(EXTRA_EXCLUDES)
+
+# cudaq is only available on linux; requirements.txt pins it with sys_platform=="linux"
+if sys.platform != "linux":
+    EXCLUDED_NOTEBOOKS.append("0_Getting_started_with_CUDA-Q.ipynb")
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
The notebook was excluded due to a CUDA-Q runtime error when declaring bit registers (RuntimeError: cannot declare bit register. Only 1 bit register(s) is/are supported). The fix landed in cuda-q 0.14 via NVIDIA/cuda-quantum#4341, and requirements.txt already pins cudaq==0.14.2.

Validated end-to-end in the NBI pipeline on AL2023 with --mock-level=LEAST in us-west-2.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-examples/blob/main/CONTRIBUTING.md) doc
- [x] I have read [docs/INSTRUCTIONS.md](https://github.com/amazon-braket/amazon-braket-examples/blob/main/docs/INSTRUCTIONS.md) and if necessary, added to `docs/ENTRIES.json` and run `docs/build_readme.sh`

#### Tests

- [x] I have verified my changes pass `pytest test/` (see [TESTING.md](https://github.com/amazon-braket/amazon-braket-examples/blob/main/TESTING.md))
- [x] If adding to `EXCLUDED_NOTEBOOKS`, I have included reason in the comment (e.g. `# Reason: requires GPU runtime`)
- [x] If modifying a notebook, I have verified no broken outputs or missing imports

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
