### PR TITLE
fix: Increase timeout for AHS noisy dynamics notebook

### DIFF
--- a/test/integ_tests/test_all_notebooks.py
+++ b/test/integ_tests/test_all_notebooks.py
@@ -14,6 +14,7 @@ DEFAULT_CELL_TIMEOUT = 600
 # Notebooks that need longer cell timeout due to heavy local simulation
 NOTEBOOK_TIMEOUTS = {
     "02_Expectation_value_calculations_with_program_sets.ipynb": 900,
+    "09_Noisy_quantum_dynamics_for_Rydberg_atom_arrays.ipynb": 900,
 }
 
 # These notebooks have syntax or dependency issues that prevent them from being tested.


### PR DESCRIPTION
The 09_Noisy_quantum_dynamics_for_Rydberg_atom_arrays notebook runs heavy local noise simulations (100 shots x 100 steps per program) that intermittently exceed the default 600s cell timeout. Bump to 900s.

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-examples/blob/main/CONTRIBUTING.md) doc
- [x] I have read [docs/INSTRUCTIONS.md](https://github.com/amazon-braket/amazon-braket-examples/blob/main/docs/INSTRUCTIONS.md) and if necessary, added to `docs/ENTRIES.json` and run `docs/build_readme.sh`

#### Tests

- [x] I have verified my changes pass `pytest test/` (see [TESTING.md](https://github.com/amazon-braket/amazon-braket-examples/blob/main/TESTING.md))
- [x] If adding to `EXCLUDED_NOTEBOOKS`, I have included reason in the comment (e.g. `# Reason: requires GPU runtime`)
- [x] If modifying a notebook, I have verified no broken outputs or missing imports

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
