### PR TITLE
fix: exclude CUDA-Q notebook in eu-north-1

### DIFF
--- a/test/integ_tests/test_all_notebooks.py
+++ b/test/integ_tests/test_all_notebooks.py
@@ -56,6 +56,8 @@ if (
         "Using_The_Adjoint_Gradient_Result_Type.ipynb",
         "0_Getting_Started.ipynb",
         "0_Creating_your_first_Hybrid_Job.ipynb",
+        # SV1 not available in eu-north-1
+        "0_Getting_started_with_CUDA-Q.ipynb",
     ]
     EXCLUDED_NOTEBOOKS.extend(EXTRA_EXCLUDES)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Excluded in eu-north since SV1 isn't available there. Tested in the NBI pipeline against us-west-2 and eu-north-1 region for test run. 

*Testing done:*
- Tested in NBI pipeline. 

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-examples/blob/main/CONTRIBUTING.md) doc
- [x] I have read [docs/INSTRUCTIONS.md](https://github.com/amazon-braket/amazon-braket-examples/blob/main/docs/INSTRUCTIONS.md) and if necessary, added to `docs/ENTRIES.json` and run `docs/build_readme.sh`

#### Tests

- [x] I have verified my changes pass `pytest test/` (see [TESTING.md](https://github.com/amazon-braket/amazon-braket-examples/blob/main/TESTING.md))
- [x] If adding to `EXCLUDED_NOTEBOOKS`, I have included reason in the comment (e.g. `# Reason: requires GPU runtime`)
- [x] If modifying a notebook, I have verified no broken outputs or missing imports

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
