### PR TITLE
fix: pin cudaq packages to cu12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,9 @@ amazon-braket-algorithm-library==1.7.6
 awscli==1.45.6
 boto3==1.43.6
 botocore==1.43.6
-cudaq==0.14.2; sys_platform=="linux"
-cudaq-qec==0.6.0; sys_platform=="linux"
-cudaq-solvers==0.6.0; sys_platform=="linux"
+cuda-quantum-cu12==0.14.2; sys_platform=="linux"
+cudaq-qec-cu12==0.6.0; sys_platform=="linux"
+cudaq-solvers-cu12==0.6.0; sys_platform=="linux"
 cvxpy==1.8.2
 ipykernel==7.2.0
 jax==0.6.2 # JAX >0.6.2 not compatible with PennyLane


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Avoid having multiple `cupy` versions by explicitly installing cu12 versions of each cudaq package.

This prevents an error like the following when running `cudaq` in the notebooks:
```
CuPy may not function correctly because multiple CuPy packages are installed
  in your environment:

    cupy-cuda12x, cupy-cuda13x
```

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-examples/blob/main/CONTRIBUTING.md) doc
- [ ] I have read [docs/INSTRUCTIONS.md](https://github.com/amazon-braket/amazon-braket-examples/blob/main/docs/INSTRUCTIONS.md) and if necessary, added to `docs/ENTRIES.json` and run `docs/build_readme.sh`

#### Tests

- [ ] I have verified my changes pass `pytest test/` (see [TESTING.md](https://github.com/amazon-braket/amazon-braket-examples/blob/main/TESTING.md))
- [ ] If adding to `EXCLUDED_NOTEBOOKS`, I have included reason in the comment (e.g. `# Reason: requires GPU runtime`)
- [ ] If modifying a notebook, I have verified no broken outputs or missing imports

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
