### PR TITLE
fix: update GPU instance types in examples

### DIFF
--- a/examples/hybrid_jobs/4_Embedded_simulators_in_Braket_Hybrid_Jobs/Embedded_simulators_in_Braket_Hybrid_Jobs.ipynb
+++ b/examples/hybrid_jobs/4_Embedded_simulators_in_Braket_Hybrid_Jobs/Embedded_simulators_in_Braket_Hybrid_Jobs.ipynb
@@ -264,11 +264,24 @@
    "source": [
     "## Accelerate your simulations with `lightning.gpu` and cuQuantum\n",
     "The PyTorch and the TensorFlow [job containers](https://docs.aws.amazon.com/braket/latest/developerguide/braket-jobs-script-environment.html?tag=local002-20) are pre-configured with [NVIDIA cuQuantum library](https://developer.nvidia.com/cuquantum-sdk) and PennyLane's [GPU simulator](https://github.com/PennyLaneAI/pennylane-lightning), `lightning.gpu`. The GPU simulator accelerates circuit simulations for bigger circuits, and increases the number of qubits that can be simulated within a given time. To use `lightning.gpu`, we need to choose a GPU instance. Braket Hybrid Jobs support these instances type that are compatible with `lightning.gpu`: \n",
-    "- g4dn.xlarge\n",
-    "- g4dn.2xlarge\n",
-    "- g4dn.4xlarge\n",
-    "- g4dn.8xlarge\n",
-    "- g4dn.12xlarge"
+    "- ml.g6.xlarge\n",
+    "- ml.g6.2xlarge\n",
+    "- ml.g6.4xlarge\n",
+    "- ml.g6.8xlarge\n",
+    "- ml.g6.12xlarge\n",
+    "- ml.g6.16xlarge\n",
+    "- ml.g6.24xlarge\n",
+    "- ml.g6.48xlarge\n",
+    "- ml.g6e.xlarge\n",
+    "- ml.g6e.2xlarge\n",
+    "- ml.g6e.4xlarge\n",
+    "- ml.g6e.8xlarge\n",
+    "- ml.g6e.12xlarge\n",
+    "- ml.g6e.16xlarge\n",
+    "- ml.g6e.24xlarge\n",
+    "- ml.g6e.48xlarge\n",
+    "\n",
+    "See the [Braket service quotas](https://docs.aws.amazon.com/braket/latest/developerguide/braket-quotas.html) for the full list of supported instance types and their default quotas.\n"
    ]
   },
   {
@@ -278,7 +291,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "instance_config = InstanceConfig(instanceType=\"ml.g4dn.2xlarge\")"
+    "instance_config = InstanceConfig(instanceType=\"ml.g6.2xlarge\")"
    ]
   },
   {
@@ -305,14 +318,6 @@
     "    \"seed\": 42,\n",
     "    \"diff_method\": \"adjoint\",\n",
     "}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3d447a14",
-   "metadata": {},
-   "source": [
-    "**Note:** The following cell may be unable to complete with the default resource limits. You may contact [AWS Support](https://support.console.aws.amazon.com/support/home#/case/create?issueType=service-limit-increase) to increase the limits on your account."
    ]
   },
   {

--- a/examples/hybrid_jobs/5_Parallelize_training_for_QML/Parallelize_training_for_QML.ipynb
+++ b/examples/hybrid_jobs/5_Parallelize_training_for_QML/Parallelize_training_for_QML.ipynb
@@ -45,7 +45,7 @@
    "source": [
     "## Training with single GPU\n",
     "\n",
-    "Let's start by running the hybrid job with `lightning.gpu` simulator on a single GPU in a `ml.g4dn.xlarge` instance which has one Nvidia T4 GPU. The algorithm script to train our quantum model is [train_single.py](source_script/train_single.py). In the algorithm script, we use PennyLane with PyTorch as our framework, which are both included in Braket's pre-configured PyTorch container. As faster demonstration, we only use a portion of the dataset (64 data points) instead of the full dataset. You can experiment with more data by setting `ndata` in the hyperparameters to a higher number, up to 208, the size of dataset. "
+    "Let's start by running the hybrid job with `lightning.gpu` simulator on a single GPU in a `ml.g6.xlarge` instance which has one NVIDIA L4 GPU. The algorithm script to train our quantum model is [train_single.py](source_script/train_single.py). In the algorithm script, we use PennyLane with PyTorch as our framework, which are both included in Braket's pre-configured PyTorch container. As faster demonstration, we only use a portion of the dataset (64 data points) instead of the full dataset. You can experiment with more data by setting `ndata` in the hyperparameters to a higher number, up to 208, the size of dataset. "
    ]
   },
   {
@@ -59,7 +59,7 @@
     "from braket.jobs.config import InstanceConfig\n",
     "from braket.jobs.image_uris import Framework, retrieve_image\n",
     "\n",
-    "instance_config = InstanceConfig(instanceType=\"ml.g4.xlarge\")\n",
+    "instance_config = InstanceConfig(instanceType=\"ml.g6.xlarge\")\n",
     "\n",
     "hyperparameters = {\n",
     "    \"nwires\": 10,\n",
@@ -82,14 +82,6 @@
    "metadata": {},
    "source": [
     "We submit our hybrid job after setting up instance configuration, hyperparameters and the hybrid job container image."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ab8a1598",
-   "metadata": {},
-   "source": [
-    "**Note:** The following cell may be unable to complete with the default resource limits. You may contact [AWS Support](https://support.console.aws.amazon.com/support/home#/case/create?issueType=service-limit-increase) to increase the limits on your account."
    ]
   },
   {
@@ -293,11 +285,11 @@
    "metadata": {},
    "source": [
     "## Training with multiple GPUs in single instance\n",
-    "With the modified algorithm, we can now submit our hybrid job with data parallelism. Amazon Braket Hybrid Jobs supports `ml.g4dn.12xlarge` for SageMaker distributed data parallel library. Be sure to choose this instance type from the list and configure it through the `InstanceConfig` argument in Jobs. See this [documentation](https://aws.amazon.com/ec2/instance-types/?tag=local002-20) for the specification, and see the [Amazon Braket pricing page](https://aws.amazon.com/braket/pricing/?tag=local002-20) for the cost of the instance type.\n",
+    "With the modified algorithm, we can now submit our hybrid job with data parallelism. Amazon Braket Hybrid Jobs supports `ml.g6.12xlarge` for SageMaker distributed data parallel library. Be sure to choose this instance type from the list and configure it through the `InstanceConfig` argument in Jobs. See this [documentation](https://aws.amazon.com/ec2/instance-types/?tag=local002-20) for the specification, and see the [Amazon Braket pricing page](https://aws.amazon.com/braket/pricing/?tag=local002-20) for the cost of the instance type.\n",
     "\n",
     "For the SageMaker distributed data parallel library to know that data parallelism is enabled, we set the `distribution` argument to be `\"data_parallel\"` when creating a hybrid job. This argument triggers Braket Hybrid Jobs to add two additional hyperparameters, `\"sagemaker_distributed_dataparallel_enabled\"` setting to `\"true\"` and `\"sagemaker_instance_type\"` setting to the instance type we are using. These two hyperparameters are used by the `smdistributed` package at runtime. You do not need to explicitly call them in the algorithm script. Keep in mind that data parallelism only works correctly when you modify your algorithm script according to the [previous section](#modify). If the data parallelism option is enabled in the hyperparameters without a correctly modified algorithm script, the hybrid job may throw errors, or each GPU may repeat the same workload without data parallelism.\n",
     "\n",
-    "<i>Warning: The ml.g4dn.12xlarge instance has higher cost per minute. Run this cell only if you are comfortable with a charge. </i>"
+    "<i>Warning: The ml.g6.12xlarge instance has higher cost per minute. Run this cell only if you are comfortable with a charge. </i>"
    ]
   },
   {
@@ -311,7 +303,7 @@
     "from braket.jobs.config import InstanceConfig\n",
     "from braket.jobs.image_uris import Framework, retrieve_image\n",
     "\n",
-    "instance_config = InstanceConfig(instanceType=\"ml.g4dn.12xlarge\")\n",
+    "instance_config = InstanceConfig(instanceType=\"ml.g6.12xlarge\")\n",
     "\n",
     "hyperparameters = {\n",
     "    \"nwires\": 10,\n",
@@ -333,15 +325,7 @@
    "id": "e707aeed",
    "metadata": {},
    "source": [
-    "With the instance type and data parallelism configured, we can now submit our hybrid job. There are 4 GPUs in a `ml.g4dn.12xlarge` instance. When the instance spins up, the workload is distributed across the 4 GPUs."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6b9e9c31",
-   "metadata": {},
-   "source": [
-    "**Note:** The following cell may be unable to complete with the default resource limits. You may contact [AWS Support](https://support.console.aws.amazon.com/support/home#/case/create?issueType=service-limit-increase) to increase the limits on your account."
+    "With the instance type and data parallelism configured, we can now submit our hybrid job. There are 4 GPUs in a `ml.g6.12xlarge` instance. When the instance spins up, the workload is distributed across the 4 GPUs."
    ]
   },
   {
@@ -411,7 +395,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "instance_config = InstanceConfig(instanceType=\"ml.g4dn.12xlarge\", instanceCount=2)"
+    "instance_config = InstanceConfig(instanceType=\"ml.g6.12xlarge\", instanceCount=2)"
    ]
   },
   {
@@ -421,7 +405,7 @@
    "source": [
     "Be mindful that, when using multiple instances, each instance incurs charge based on how long you use it. In distributed data parallelism, when you set `instanceCount=2`, two instances are allocated to run your hybrid job. SageMaker distributed library managed the instances that they start and end at the same time. If your workload takes 200 seconds, you will be billed for 200 seconds for each instance used, which adds to 400 seconds in total.\n",
     "\n",
-    "<i> Warning: The g4dn.12xlarge instance has higher cost per minute. Run this cell only if you are comfortable with the charge. </i>"
+    "<i> Warning: The g6.12xlarge instance has higher cost per minute. Run this cell only if you are comfortable with the charge. </i>"
    ]
   },
   {
@@ -456,14 +440,6 @@
    "metadata": {},
    "source": [
     "Now we can submit our hybrid job with distributed data parallelism!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0842096f",
-   "metadata": {},
-   "source": [
-    "**Note:** The following cell may be unable to complete with the default resource limits. You may contact [AWS Support](https://support.console.aws.amazon.com/support/home#/case/create?issueType=service-limit-increase) to increase the limits on your account."
    ]
   },
   {

--- a/examples/hybrid_jobs/5_Parallelize_training_for_QML/Parallelize_training_for_QML.ipynb
+++ b/examples/hybrid_jobs/5_Parallelize_training_for_QML/Parallelize_training_for_QML.ipynb
@@ -443,6 +443,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "753f18a0",
+   "metadata": {},
+   "source": [
+    "**Note:** The following cell may be unable to complete with the default resource limits. You may contact [AWS Support](https://support.console.aws.amazon.com/support/home#/case/create?issueType=service-limit-increase) to increase the limits on your account."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 14,
    "id": "fe83fd35",

--- a/examples/hybrid_jobs/6_QNSPSA_optimizer_with_embedded_simulator/qnspsa_with_embedded_simulator.ipynb
+++ b/examples/hybrid_jobs/6_QNSPSA_optimizer_with_embedded_simulator/qnspsa_with_embedded_simulator.ipynb
@@ -847,14 +847,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "96364c00",
-   "metadata": {},
-   "source": [
-    "**Note:** The following cell may be unable to complete with the default resource limits. You may contact [AWS Support](https://support.console.aws.amazon.com/support/home#/case/create?issueType=service-limit-increase) to increase the limits on your account."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "fa4c091f",
@@ -879,8 +871,8 @@
     "    \"max_iter\": 60,\n",
     "    \"learn_rate\": 1e-2,\n",
     "}\n",
-    "# ml.g4dn.xlarge provides a T4 GPU for the GPU simulator to run\n",
-    "instance_config = InstanceConfig(instanceType='ml.g4dn.xlarge', volumeSizeInGb=30, instanceCount=1)\n",
+    "# ml.g6.xlarge provides an L4 GPU for the GPU simulator to run\n",
+    "instance_config = InstanceConfig(instanceType='ml.g6.xlarge', volumeSizeInGb=30, instanceCount=1)\n",
     "\n",
     "job_name = f\"qaoa-large-problem-gpu-qubits{n_qubits}-\" + str(int(time.time()))\n",
     "\n",

--- a/examples/nvidia_cuda_q/4_Simulation_with_GPUs.ipynb
+++ b/examples/nvidia_cuda_q/4_Simulation_with_GPUs.ipynb
@@ -60,7 +60,7 @@
    "metadata": {},
    "source": [
     "## Running hybrid jobs on GPUs\n",
-    "To use GPUs for circuit simulation, you can set the target backend to `nvidia`. You also need to select an instance that has NVIDIA GPUs. In the code snippet below, the instance type \"ml.g4dn.xlarge\" is used as an example. The instance type \"ml.g4dn.xlarge\" has a single [NVIDIA T4 GPU](https://aws.amazon.com/ec2/instance-types/g4/). You can check [this page](https://aws.amazon.com/braket/pricing/) and [this page](https://docs.aws.amazon.com/braket/latest/developerguide/braket-jobs-configure-job-instance-for-script.html) to view available instances for Braket Hybrid Jobs. The `include_modules` keyword is set to `random_circuits` in order to use the random circuit generator defined in \"random_circuits.py\"."
+    "To use GPUs for circuit simulation, you can set the target backend to `nvidia`. You also need to select an instance that has NVIDIA GPUs. In the code snippet below, the instance type \"ml.g6e.xlarge\" is used as an example. The instance type \"ml.g6e.xlarge\" has a single [NVIDIA L40S GPU](https://aws.amazon.com/ec2/instance-types/g6e/). You can check [this page](https://aws.amazon.com/braket/pricing/) and [this page](https://docs.aws.amazon.com/braket/latest/developerguide/braket-jobs-configure-job-instance-for-script.html) to view available instances for Braket Hybrid Jobs. The `include_modules` keyword is set to `random_circuits` in order to use the random circuit generator defined in \"random_circuits.py\"."
    ]
   },
   {
@@ -74,7 +74,7 @@
     "    device=\"local:nvidia/nvidia\",\n",
     "    image_uri=image_uri,\n",
     "    include_modules=\"random_circuits\",\n",
-    "    instance_config=InstanceConfig(instanceType=\"ml.g4dn.xlarge\"),\n",
+    "    instance_config=InstanceConfig(instanceType=\"ml.g6e.xlarge\"),\n",
     ")\n",
     "def gpu_job(n_qubits, n_gates, n_terms, n_shots):\n",
     "    import cudaq\n",
@@ -148,7 +148,7 @@
     "    device=\"local:nvidia/tensornet\",\n",
     "    image_uri=image_uri,\n",
     "    include_modules=\"random_circuits\",\n",
-    "    instance_config=InstanceConfig(instanceType=\"ml.g4dn.xlarge\"),\n",
+    "    instance_config=InstanceConfig(instanceType=\"ml.g6e.xlarge\"),\n",
     ")\n",
     "def gpu_tn_job(n_qubits, n_gates, n_terms, n_shots):\n",
     "    import cudaq\n",

--- a/examples/nvidia_cuda_q/5_Multiple_GPU_simulations.ipynb
+++ b/examples/nvidia_cuda_q/5_Multiple_GPU_simulations.ipynb
@@ -62,7 +62,7 @@
    "source": [
     "## Simulation on a single GPU\n",
     "\n",
-    "We start by running a job on a single GPU. This example job evaluates a circuit with terms in a Hamiltonian. The ml.g6e.2xlarge instance type used in the example has one GPU."
+    "We start by running a job on a single GPU. This example job evaluates a circuit with terms in a Hamiltonian. The ml.g6e.xlarge instance type used in the example has one GPU."
    ]
   },
   {

--- a/examples/nvidia_cuda_q/5_Multiple_GPU_simulations.ipynb
+++ b/examples/nvidia_cuda_q/5_Multiple_GPU_simulations.ipynb
@@ -62,7 +62,7 @@
    "source": [
     "## Simulation on a single GPU\n",
     "\n",
-    "We start by running a job on a single GPU. This example job evaluates a circuit with terms in a Hamiltonian. The ml.p3.2xlarge instance type used in the example has one GPU."
+    "We start by running a job on a single GPU. This example job evaluates a circuit with terms in a Hamiltonian. The ml.g6e.2xlarge instance type used in the example has one GPU."
    ]
   },
   {
@@ -74,7 +74,7 @@
    "source": [
     "@hybrid_job(\n",
     "    device=\"local:nvidia/nvidia\",\n",
-    "    instance_config=InstanceConfig(instanceType=\"ml.g4dn.xlarge\"),\n",
+    "    instance_config=InstanceConfig(instanceType=\"ml.g6e.xlarge\"),\n",
     "    image_uri=image_uri,\n",
     ")\n",
     "def single_gpu_job(n_qubits, n_terms, n_shots):\n",
@@ -163,7 +163,7 @@
     "\n",
     "Let's tackle the same problem again. But this time, we will run the simulation on multiple GPUs across multiple nodes using the [MPI interface](https://nvidia.github.io/cuda-quantum/latest/using/install/data_center_install.html#mpi). To do so, you add the keyword argument `execution=cudaq.parallel.mpi` to the `cudaq.observe()` call. With this keyword argument, CUDA-Q will distribute the simulation over the GPUs available in a job.\n",
     "\n",
-    "For CUDA-Q to distribute the simulation, there are some prerequisites. First, the job needs to run on instances that have many GPUs. To achieve this, you can specify an instance type that has multiple GPUs (e.g., ml.g4dn.12xlarge). If the number of GPUs on a single instance is not enough, you can extend the parallelization to multiple nodes by specifying `instanceCount` to be larger than 1. Then, you need to add a hyperparameter `sagemaker_mpi_enabled=True` to the job, which will initialize the job environment to support parallelization with MPI. Next, you need to select a CUDA-Q backend that supports distribution (e.g., `nvidia` backend with the `mqpu` option). Finally, you need to initialize the MPI interface in your CUDA-Q code. The code snippet below provides example of all these steps."
+    "For CUDA-Q to distribute the simulation, there are some prerequisites. First, the job needs to run on instances that have many GPUs. To achieve this, you can specify an instance type that has multiple GPUs (e.g., ml.g6e.12xlarge). If the number of GPUs on a single instance is not enough, you can extend the parallelization to multiple nodes by specifying `instanceCount` to be larger than 1. Then, you need to add a hyperparameter `sagemaker_mpi_enabled=True` to the job, which will initialize the job environment to support parallelization with MPI. Next, you need to select a CUDA-Q backend that supports distribution (e.g., `nvidia` backend with the `mqpu` option). Finally, you need to initialize the MPI interface in your CUDA-Q code. The code snippet below provides example of all these steps."
    ]
   },
   {
@@ -175,7 +175,7 @@
    "source": [
     "@hybrid_job(\n",
     "    device=\"local:nvidia/nvidia-mqpu\",\n",
-    "    instance_config=InstanceConfig(instanceType=\"ml.g4dn.12xlarge\", instanceCount=1),\n",
+    "    instance_config=InstanceConfig(instanceType=\"ml.g6e.12xlarge\", instanceCount=1),\n",
     "    image_uri=image_uri,\n",
     ")\n",
     "def parallel_observables_gpu_job(\n",
@@ -303,7 +303,7 @@
    "source": [
     "@hybrid_job(\n",
     "    device=\"local:nvidia/nvidia-mqpu\",\n",
-    "    instance_config=InstanceConfig(instanceType=\"ml.g4dn.12xlarge\"),\n",
+    "    instance_config=InstanceConfig(instanceType=\"ml.g6e.12xlarge\"),\n",
     "    include_modules=\"random_circuits\",\n",
     "    image_uri=image_uri,\n",
     ")\n",

--- a/examples/nvidia_cuda_q/6_Distributed_state_vector_simulations.ipynb
+++ b/examples/nvidia_cuda_q/6_Distributed_state_vector_simulations.ipynb
@@ -9,10 +9,7 @@
     "\n",
     "In the notebook \"5_Multiple_GPU_simulations.ipynb\", you learned how to use CUDA-Q and Braket Hybrid Jobs to parallelize the simulation of a batch of observables and circuits over multiple GPUs, where each GPU simulates a single QPU. For workloads with larger qubit counts, however, it may be necessary to distribute a single state vector simulation across multiple GPUs so that multiple GPUs together simulate a single QPU.\n",
     "\n",
-    "In this notebook, you will learn how to use CUDA-Q and Braket Hybrid Jobs to tackle this.\n",
-    "\n",
-    "**Prerequisites:**\n",
-    "- Instance count quota >= 1 for `ml.g6.12xlarge` (or the GPU instance type you choose)"
+    "In this notebook, you will learn how to use CUDA-Q and Braket Hybrid Jobs to tackle this."
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Available hybrid job instance types were recently updated to include ml.g6 and ml.g6e family GPU instances, and these now have a non-zero default quota, making them a much better choice for our example notebooks. Updating relevant notebooks to use these instances, and removing comments about insufficient default resource limits.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-examples/blob/main/CONTRIBUTING.md) doc
- [x] I have read [docs/INSTRUCTIONS.md](https://github.com/amazon-braket/amazon-braket-examples/blob/main/docs/INSTRUCTIONS.md) and if necessary, added to `docs/ENTRIES.json` and run `docs/build_readme.sh`

#### Tests

- [x] I have verified my changes pass `pytest test/` (see [TESTING.md](https://github.com/amazon-braket/amazon-braket-examples/blob/main/TESTING.md))
- [x] If adding to `EXCLUDED_NOTEBOOKS`, I have included reason in the comment (e.g. `# Reason: requires GPU runtime`)
- [x] If modifying a notebook, I have verified no broken outputs or missing imports

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
