### PR TITLE
fix: remove deprecated custom_decomps kwarg

### DIFF
--- a/examples/hybrid_jobs/4_Embedded_simulators_in_Braket_Hybrid_Jobs/qaoa/utils.py
+++ b/examples/hybrid_jobs/4_Embedded_simulators_in_Braket_Hybrid_Jobs/qaoa/utils.py
@@ -9,11 +9,7 @@ def get_device(n_wires):
 
     if device_prefix == "local":
         _prefix, device_name = device_string.split("/")
-        device = qml.device(
-            device_name,
-            wires=n_wires,
-            custom_decomps={"MultiRZ": qml.MultiRZ.compute_decomposition},
-        )
+        device = qml.device(device_name, wires=n_wires)
         print("Using local simulator: ", device.name)
     else:
         device = qml.device(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove the `custom_decomps` kwarg from `qaoa/utils.py`'s local-device construction. PennyLane 0.45+ no longer accepts that kwarg on `default.qubit`/`lightning.*` ([see this page](https://docs.pennylane.ai/en/stable/development/deprecations.html#completed-deprecation-cycles)). Those default backends support `MultiRZ` natively, so the decomposition was a no-op.

*Testing done:*
Notebook succeeds with latest PennyLane release.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-examples/blob/main/CONTRIBUTING.md) doc
- [x] I have read [docs/INSTRUCTIONS.md](https://github.com/amazon-braket/amazon-braket-examples/blob/main/docs/INSTRUCTIONS.md) and if necessary, added to `docs/ENTRIES.json` and run `docs/build_readme.sh`

#### Tests

- [x] I have verified my changes pass `pytest test/` (see [TESTING.md](https://github.com/amazon-braket/amazon-braket-examples/blob/main/TESTING.md))
- [x] If adding to `EXCLUDED_NOTEBOOKS`, I have included reason in the comment (e.g. `# Reason: requires GPU runtime`)
- [x] If modifying a notebook, I have verified no broken outputs or missing imports

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
