### PR TITLE
fix: drop cell execution loops for larger simulation params

### DIFF
--- a/test/integ_tests/analog_hamiltonian_simulation/09_Noisy_quantum_dynamics_for_Rydberg_atom_arrays_mocks.py
+++ b/test/integ_tests/analog_hamiltonian_simulation/09_Noisy_quantum_dynamics_for_Rydberg_atom_arrays_mocks.py
@@ -1,3 +1,6 @@
+import re
+
+
 def pre_run_inject(mock_utils):
     mocker = mock_utils.Mocker()
     mock_utils.mock_default_device_calls(mocker)
@@ -8,6 +11,17 @@ def pre_run_inject(mock_utils):
         },
     )
     mocker.set_task_result_return(mock_utils.read_file("ahs_results.json", __file__))
+
+
+def modify_cells(cells):
+    for cell in cells:
+        if cell.get("cell_type") != "code":
+            continue
+        src = cell["source"]
+        src = re.sub(r"n_times = 19", "n_times = 3", src)
+        src = re.sub(r"shots=100, steps=100", "shots=2, steps=5", src)
+        src = re.sub(r"shots=1000, steps=100", "shots=2, steps=5", src)
+        cell["source"] = src
 
 
 def post_run(tb):

--- a/test/integ_tests/braket_features/program_sets/02_Expectation_value_calculations_with_program_sets_mocks.py
+++ b/test/integ_tests/braket_features/program_sets/02_Expectation_value_calculations_with_program_sets_mocks.py
@@ -1,0 +1,20 @@
+import re
+
+
+def pre_run_inject(mock_utils):
+    mocker = mock_utils.Mocker()
+    mock_utils.mock_default_device_calls(mocker)
+
+
+def modify_cells(cells):
+    for cell in cells:
+        if cell.get("cell_type") != "code":
+            continue
+        src = cell["source"]
+        src = re.sub(r"num_trials = 100", "num_trials = 3", src)
+        src = re.sub(r"total_shots = 10000", "total_shots = 100", src)
+        cell["source"] = src
+
+
+def post_run(tb):
+    pass

--- a/test/integ_tests/test_all_notebooks.py
+++ b/test/integ_tests/test_all_notebooks.py
@@ -13,10 +13,7 @@ UNCOMMENT_NOTEBOOK_TAG = "## UNCOMMENT_TO_RUN"
 DEFAULT_CELL_TIMEOUT = 600
 
 # Notebooks that need longer cell timeout due to heavy local simulation
-NOTEBOOK_TIMEOUTS = {
-    "02_Expectation_value_calculations_with_program_sets.ipynb": 900,
-    "09_Noisy_quantum_dynamics_for_Rydberg_atom_arrays.ipynb": 1200,
-}
+NOTEBOOK_TIMEOUTS = {}
 
 # These notebooks have syntax or dependency issues that prevent them from being tested.
 EXCLUDED_NOTEBOOKS = [
@@ -159,7 +156,6 @@ def check_cells_for_error_output(cells):
 
 
 def execute_with_mocks(tb, mock_level, path_to_utils, path_to_mocks):
-    # We do this check to make sure that the notebook can be executed (with mocks).
     tb.inject(
         f"""
         from importlib.machinery import SourceFileLoader
@@ -172,18 +168,19 @@ def execute_with_mocks(tb, mock_level, path_to_utils, path_to_mocks):
         before=0,
     )
 
-    # Uncomment all test sections in the notebook
+    test_mocks = SourceFileLoader("notebook_mocks", path_to_mocks).load_module()
+
+    if hasattr(test_mocks, "modify_cells"):
+        test_mocks.modify_cells(tb.cells)
+
     for i, cell in enumerate(tb.cells):
         if cell.get("cell_type") == "code" and "source" in cell:
             source = cell["source"]
             if UNCOMMENT_NOTEBOOK_TAG in source:
-                # Uncomment the test section
                 modified_source = uncomment_test_section(source)
                 tb.cells[i]["source"] = modified_source
 
-    # Execute the notebook with the uncommented test sections
     tb.execute()
-    test_mocks = SourceFileLoader("notebook_mocks", path_to_mocks).load_module()
     test_mocks.post_run(tb)
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The main aim here is to add test configurable settings to avoid running all step iterations for simulations. In this case, reducing optimization looks and shot numbers.

Runtimes drop dramatically due to this without mutating the customer cells: https://github.com/amazon-braket/amazon-braket-examples/pull/915/checks

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-examples/blob/main/CONTRIBUTING.md) doc
- [ ] I have read [docs/INSTRUCTIONS.md](https://github.com/amazon-braket/amazon-braket-examples/blob/main/docs/INSTRUCTIONS.md) and if necessary, added to `docs/ENTRIES.json` and run `docs/build_readme.sh`

#### Tests

- [ ] I have verified my changes pass `pytest test/` (see [TESTING.md](https://github.com/amazon-braket/amazon-braket-examples/blob/main/TESTING.md))
- [ ] If adding to `EXCLUDED_NOTEBOOKS`, I have included reason in the comment (e.g. `# Reason: requires GPU runtime`)
- [ ] If modifying a notebook, I have verified no broken outputs or missing imports

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
