### PR TITLE
Read device gates via OpenQASM action key in two notebooks

### DIFF
--- a/examples/advanced_circuits_algorithms/Grover/Grover.ipynb
+++ b/examples/advanced_circuits_algorithms/Grover/Grover.ipynb
@@ -430,7 +430,7 @@
     "# show the properties of the device\n",
     "device_properties = device.properties\n",
     "# show supportedQuantumOperations (supported gates for a device)\n",
-    "device_operations = device_properties.dict()[\"action\"][\"braket.ir.jaqcd.program\"][\n",
+    "device_operations = device_properties.dict()[\"action\"][\"braket.ir.openqasm.program\"][\n",
     "    \"supportedOperations\"\n",
     "]\n",
     "# Note: This field also exists for other devices like the QPUs\n",

--- a/examples/getting_started/3_Deep_dive_into_the_anatomy_of_quantum_circuits/3_Deep_dive_into_the_anatomy_of_quantum_circuits.ipynb
+++ b/examples/getting_started/3_Deep_dive_into_the_anatomy_of_quantum_circuits/3_Deep_dive_into_the_anatomy_of_quantum_circuits.ipynb
@@ -878,7 +878,7 @@
     "# show the properties of the device\n",
     "device_properties = device.properties\n",
     "# show supportedQuantumOperations (supported gates for a device)\n",
-    "device_operations = device_properties.dict()[\"action\"][\"braket.ir.jaqcd.program\"][\n",
+    "device_operations = device_properties.dict()[\"action\"][\"braket.ir.openqasm.program\"][\n",
     "    \"supportedOperations\"\n",
     "]\n",
     "# Note: This field also exists for other devices like the QPUs\n",


### PR DESCRIPTION
Removing JAQCD actions from the examples since JAQCD is being deprecated. See related bdk change: https://github.com/amazon-braket/amazon-braket-sdk-python/pull/1266

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-examples/blob/main/CONTRIBUTING.md) doc
- [x] I have read [docs/INSTRUCTIONS.md](https://github.com/amazon-braket/amazon-braket-examples/blob/main/docs/INSTRUCTIONS.md) and if necessary, added to `docs/ENTRIES.json` and run `docs/build_readme.sh`

#### Tests

- [x] I have verified my changes pass `pytest test/` (see [TESTING.md](https://github.com/amazon-braket/amazon-braket-examples/blob/main/TESTING.md))
- [x] If adding to `EXCLUDED_NOTEBOOKS`, I have included reason in the comment (e.g. `# Reason: requires GPU runtime`)
- [x] If modifying a notebook, I have verified no broken outputs or missing imports

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
