### PR TITLE
infra: allow for longer running tests to be sorted first for pytest worksteal

### DIFF
--- a/test/integ_tests/conftest.py
+++ b/test/integ_tests/conftest.py
@@ -41,12 +41,44 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     config.addinivalue_line("markers", "mitiq: tests only specific to mitiq-related notebooks")
 
+# Known test durations (seconds) to ensure xdist schedules slow tests first.
+# This prevents long-running tests from clustering on a single worker.
+NOTEBOOK_DURATIONS = {
+    "06_Analog_Hamiltonian_simulation_with_PennyLane.ipynb": 70,
+    "Quantum_machine_learning_in_Amazon_Braket_Hybrid_Jobs.ipynb": 57,
+    "QAOA_braket.ipynb": 32,
+    "3_Hydrogen_Molecule_geometry_with_VQE.ipynb": 30,
+    "Using_PennyLane_with_Braket_Hybrid_Jobs.ipynb": 28,
+    "0_Creating_your_first_Hybrid_Job.ipynb": 28,
+    "VQE_chemistry_braket.ipynb": 26,
+    "2_Graph_optimization_with_QAOA.ipynb": 26,
+    "01_Local_Emulation_for_Verbatim_Circuits_on_Amazon_Braket.ipynb": 24,
+    "4_Simulation_of_noisy_quantum_circuits_on_Amazon_Braket_with_PennyLane.ipynb": 20,
+    "0_Getting_Started.ipynb": 17,
+    "VQE_Transverse_Ising_Model.ipynb": 17,
+    "05_Running_Analog_Hamiltonian_Simulation_with_local_simulator.ipynb": 16,
+    "02_Expectation_value_calculations_with_program_sets.ipynb": 16,
+    "Advanced_QPU_workflow.ipynb": 14,
+    "1_Parallelized_optimization_of_quantum_circuits.ipynb": 14,
+    "Running_notebooks_as_hybrid_jobs.ipynb": 14,
+}
+
+
 def pytest_collection_modifyitems(config, items):
     if not config.getoption("--test-mitiq"):
         skip_mitiq = pytest.mark.skip(reason="need --test-mitiq option to run")
         for item in items:
             if "mitiq" in item.keywords:
                 item.add_marker(skip_mitiq)
+
+    # Sort by expected duration descending so xdist worksteal starts slow tests first
+    def _get_duration(item):
+        for name, duration in NOTEBOOK_DURATIONS.items():
+            if name in item.nodeid:
+                return duration
+        return 0
+
+    items.sort(key=_get_duration, reverse=True)
 
 @pytest.fixture
 def mock_level(request):


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*

Attempting to get the longer running tests started first to avoid the tail end being the long pull.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-examples/blob/main/CONTRIBUTING.md) doc
- [ ] I have read [docs/INSTRUCTIONS.md](https://github.com/amazon-braket/amazon-braket-examples/blob/main/docs/INSTRUCTIONS.md) and if necessary, added to `docs/ENTRIES.json` and run `docs/build_readme.sh`

#### Tests

- [ ] I have verified my changes pass `pytest test/` (see [TESTING.md](https://github.com/amazon-braket/amazon-braket-examples/blob/main/TESTING.md))
- [ ] If adding to `EXCLUDED_NOTEBOOKS`, I have included reason in the comment (e.g. `# Reason: requires GPU runtime`)
- [ ] If modifying a notebook, I have verified no broken outputs or missing imports

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
