### PR TITLE
test: remove stale NOTEBOOK_DURATIONS entries for notebooks sped up by #942

### DIFF
--- a/test/integ_tests/conftest.py
+++ b/test/integ_tests/conftest.py
@@ -54,13 +54,9 @@ def pytest_configure(config):
 # Known test durations (seconds) to ensure xdist schedules slow tests first.
 # This prevents long-running tests from clustering on a single worker.
 NOTEBOOK_DURATIONS = {
-    "06_Analog_Hamiltonian_simulation_with_PennyLane.ipynb": 70,
-    "Quantum_machine_learning_in_Amazon_Braket_Hybrid_Jobs.ipynb": 57,
     "QAOA_braket.ipynb": 32,
-    "3_Hydrogen_Molecule_geometry_with_VQE.ipynb": 30,
     "Using_PennyLane_with_Braket_Hybrid_Jobs.ipynb": 28,
     "0_Creating_your_first_Hybrid_Job.ipynb": 28,
-    "VQE_chemistry_braket.ipynb": 26,
     "2_Graph_optimization_with_QAOA.ipynb": 26,
     "01_Local_Emulation_for_Verbatim_Circuits_on_Amazon_Braket.ipynb": 24,
     "4_Simulation_of_noisy_quantum_circuits_on_Amazon_Braket_with_PennyLane.ipynb": 20,


### PR DESCRIPTION
## Issue

`NOTEBOOK_DURATIONS` in [`test/integ_tests/conftest.py`](test/integ_tests/conftest.py) is used to sort tests longest-first for `pytest-xdist --dist worksteal`, so long-running notebooks are dispatched before short ones. PR #942 (`test: speed up four slowest integ-test notebooks`) added `modify_cells` hooks that reduce iteration/shot counts on 4 specific notebooks. Their real runtime dropped by ~1–2 orders of magnitude, but their entries in `NOTEBOOK_DURATIONS` still list the pre-#942 estimates:

| Sort position | Notebook | Duration in map | Real runtime after PR #942 |
|:-:|-|:-:|:-:|
| 1 | `06_Analog_Hamiltonian_simulation_with_PennyLane.ipynb` | 70 s | ~13 s (n_epochs 10→3, shots 1000→100) |
| 2 | `Quantum_machine_learning_in_Amazon_Braket_Hybrid_Jobs.ipynb` | 57 s | small fraction (`n_iterations=5→1`) |
| 4 | `3_Hydrogen_Molecule_geometry_with_VQE.ipynb` | 30 s | small fraction (iterations 7→3, shots 5000→500) |
| 8 | `VQE_chemistry_braket.ipynb` | 26 s | ~1 s (28×24 grid → 6×6, ~18× reduction) |

The four now-fast notebooks occupy positions 1, 2, 4, 8 of the priority queue despite finishing quickest, which defeats the "slow tests first" scheduling that `NOTEBOOK_DURATIONS` is meant to enable.

## Fix

Delete the 4 stale entries. Those notebooks fall back to `duration=0` and land in the middle/bottom of the sort, so the still-slow notebooks (`QAOA_braket`, `0_Creating_your_first_Hybrid_Job`, etc.) run first as intended.

## Local verification

```
$ python -m pytest test/integ_tests/test_all_notebooks.py --collect-only -q
```

| Notebook | Position before fix | Position after fix |
|-|:-:|:-:|
| `06_Analog_Hamiltonian_simulation_with_PennyLane.ipynb` | 1 | 19 |
| `Quantum_machine_learning_in_Amazon_Braket_Hybrid_Jobs.ipynb` | 2 | 31 |
| `3_Hydrogen_Molecule_geometry_with_VQE.ipynb` | 4 | 40 |
| `VQE_chemistry_braket.ipynb` | 8 | 78 |
